### PR TITLE
Fixes SpotlightListItem scroll crash

### DIFF
--- a/ThunderCloud/SpotlightListItemCell.swift
+++ b/ThunderCloud/SpotlightListItemCell.swift
@@ -113,13 +113,8 @@ open class SpotlightListItemCell: StormTableViewCell {
         
         var nextItem: Int = 0
         
-        if currentPage <= pageIndicator.numberOfPages - 1 {
+        if currentPage < spotlights.count - 1 {
             nextItem = currentPage + 1
-        }
-        
-        // If we've gone past the amount of spotlights that's available, return to the first item.
-        if nextItem >= spotlights.count {
-            nextItem = 0
         }
         
         let index = IndexPath(item: nextItem, section: 0)

--- a/ThunderCloud/SpotlightListItemCell.swift
+++ b/ThunderCloud/SpotlightListItemCell.swift
@@ -107,19 +107,24 @@ open class SpotlightListItemCell: StormTableViewCell {
     }
     
     @objc func cycleSpotlight(timer: Timer) {
-        
-        if pageIndicator.currentPage + 1 >= pageIndicator.numberOfPages {
-            
-            let firstIndex = IndexPath(item: 0, section: 0)
-            collectionView.scrollToItem(at: firstIndex, at: .left, animated: true)
-            currentPage = 0
-            
-        } else {
-            
-            let nextIndex = IndexPath(item: currentPage + 1, section: 0)
-            collectionView.scrollToItem(at: nextIndex, at: .left, animated: true)
-            currentPage = currentPage + 1
+        guard let spotlights = spotlights, spotlights.count > 0 else {
+            return
         }
+        
+        var nextItem: Int = 0
+        
+        if currentPage <= pageIndicator.numberOfPages - 1 {
+            nextItem = currentPage + 1
+        }
+        
+        // If we've gone past the amount of spotlights that's available, return to the first item.
+        if nextItem >= spotlights.count {
+            nextItem = 0
+        }
+        
+        let index = IndexPath(item: nextItem, section: 0)
+        collectionView.scrollToItem(at: index, at: .left, animated: true)
+        currentPage = nextItem
     }
     
     open func configure(spotlightCell: SpotlightImageCollectionViewCell, with spotlight: Spotlight) {


### PR DESCRIPTION
There was a crash in one of the apps, where there were no spotlights available when the automatic scroll timer fired and due to this, the app would crash.

This fixes this, by checking that there are spotlights and that the current page is within the correct bounds.