### PR TITLE
Fixes ExternalLink navigation

### DIFF
--- a/ThunderCloud.xcodeproj/project.pbxproj
+++ b/ThunderCloud.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		49F12CA91E4370C700EC2321 /* StormGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F12CA81E4370C700EC2321 /* StormGenerator.swift */; };
 		49FC635E1EE1650D0018D293 /* StormLanguageController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FC635D1EE1650D0018D293 /* StormLanguageController.swift */; };
 		981EBDAE22C2691F00BAAD89 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 981EBDAD22C2691F00BAAD89 /* Settings.bundle */; };
+		9863CED422D4DFA900E52D79 /* UIWindow+RightMostNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9863CED322D4DFA900E52D79 /* UIWindow+RightMostNavigationController.swift */; };
 		B104A4661FA7800800DDBB22 /* DummyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B104A4651FA7800800DDBB22 /* DummyViewController.swift */; };
 		B104A4681FA7815B00DDBB22 /* NavigationTabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B104A4671FA7815B00DDBB22 /* NavigationTabBarViewController.swift */; };
 		B10831A91F06924F008B565D /* AnimatedImageListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10831A81F06924F008B565D /* AnimatedImageListCell.swift */; };
@@ -340,6 +341,7 @@
 		49F12CA81E4370C700EC2321 /* StormGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StormGenerator.swift; sourceTree = "<group>"; };
 		49FC635D1EE1650D0018D293 /* StormLanguageController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StormLanguageController.swift; sourceTree = "<group>"; };
 		981EBDAD22C2691F00BAAD89 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = Settings.bundle; path = ThunderCloud/Settings.bundle; sourceTree = "<group>"; };
+		9863CED322D4DFA900E52D79 /* UIWindow+RightMostNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindow+RightMostNavigationController.swift"; sourceTree = "<group>"; };
 		B104A4651FA7800800DDBB22 /* DummyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyViewController.swift; sourceTree = "<group>"; };
 		B104A4671FA7815B00DDBB22 /* NavigationTabBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationTabBarViewController.swift; sourceTree = "<group>"; };
 		B10831A81F06924F008B565D /* AnimatedImageListCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatedImageListCell.swift; sourceTree = "<group>"; };
@@ -743,6 +745,7 @@
 			children = (
 				B15103061FAB3E740044A4AC /* IdentifiableViewController.swift */,
 				B1BAAC2222253D7A007F0F61 /* NavigationController+Conformance.swift */,
+				9863CED322D4DFA900E52D79 /* UIWindow+RightMostNavigationController.swift */,
 			);
 			name = Categories;
 			sourceTree = "<group>";
@@ -1351,6 +1354,7 @@
 				B11064A71F4B1FF8003E5814 /* BadgeController.swift in Sources */,
 				B13778C5202895C8006FE6D5 /* ImageSelectionQuestion.swift in Sources */,
 				B179EC3E1F0FC8BC0007ED3F /* TextListItemCell.swift in Sources */,
+				9863CED422D4DFA900E52D79 /* UIWindow+RightMostNavigationController.swift in Sources */,
 				B1163E791F0CF27400A9E8E2 /* UnorderedListItemCell.swift in Sources */,
 				B179EC221F0F8E980007ED3F /* LocalisationEditViewController.swift in Sources */,
 				B10832791F0BD547008B565D /* CustomUploadListItemView.swift in Sources */,

--- a/ThunderCloud/NavigationController.swift
+++ b/ThunderCloud/NavigationController.swift
@@ -190,8 +190,12 @@ public extension UINavigationController {
 			UIApplication.shared.open(url, options: [:], completionHandler: nil)
 			
 		} else {
-            guard let rightMostNavigationController = UIApplication.shared.keyWindow?.rightMostNavigationController else {
-                return
+            var navigationController = self
+            
+            // Attempt to access the key window's right-most navigation controller.
+            // This resolves an issue on iPad where the SFSafariViewController is not presented correctly.
+            if let rightMostNavigationController = UIApplication.shared.keyWindow?.rightMostNavigationController {
+                navigationController = rightMostNavigationController
             }
 			
 			var url: URL?
@@ -205,13 +209,13 @@ public extension UINavigationController {
 			guard let _url = url else { return }
 			
 			let safariViewController = SFSafariViewController(url: _url)
-			safariViewController.delegate = rightMostNavigationController
+			safariViewController.delegate = navigationController
 			safariViewController.view.tintColor = ThemeManager.shared.theme.mainColor
 			
 			safariViewController.preferredControlTintColor = ThemeManager.shared.theme.titleTextColor
 			safariViewController.preferredBarTintColor = ThemeManager.shared.theme.navigationBarBackgroundColor
 			
-			rightMostNavigationController.present(safariViewController, animated: true, completion: nil)
+			navigationController.present(safariViewController, animated: true, completion: nil)
 		}
 		
 		guard let url = link.url else { return }

--- a/ThunderCloud/NavigationController.swift
+++ b/ThunderCloud/NavigationController.swift
@@ -190,6 +190,9 @@ public extension UINavigationController {
 			UIApplication.shared.open(url, options: [:], completionHandler: nil)
 			
 		} else {
+            guard let rightMostNavigationController = UIApplication.shared.keyWindow?.rightMostNavigationController else {
+                return
+            }
 			
 			var url: URL?
 			
@@ -202,13 +205,13 @@ public extension UINavigationController {
 			guard let _url = url else { return }
 			
 			let safariViewController = SFSafariViewController(url: _url)
-			safariViewController.delegate = self
+			safariViewController.delegate = rightMostNavigationController
 			safariViewController.view.tintColor = ThemeManager.shared.theme.mainColor
 			
 			safariViewController.preferredControlTintColor = ThemeManager.shared.theme.titleTextColor
 			safariViewController.preferredBarTintColor = ThemeManager.shared.theme.navigationBarBackgroundColor
 			
-			present(safariViewController, animated: true, completion: nil)
+			rightMostNavigationController.present(safariViewController, animated: true, completion: nil)
 		}
 		
 		guard let url = link.url else { return }

--- a/ThunderCloud/UIWindow+RightMostNavigationController.swift
+++ b/ThunderCloud/UIWindow+RightMostNavigationController.swift
@@ -1,0 +1,24 @@
+//
+//  UIWindow+RightMostNavigationController.swift
+//  ThunderCloud
+//
+//  Created by Ryan Bourne on 09/07/2019.
+//  Copyright © 2019 3 SIDED CUBE. All rights reserved.
+//
+
+import Foundation
+
+extension UIWindow {
+    
+    /// Attempts to fetch the right-most UINavigationController from the window's rootViewController.
+    ///
+    /// We do this, as to provide a consistent way of:
+    ///     - Retrieving the 'detail' part of a UISplitViewController on iPad.
+    ///     - Retrieving the standard navigation controller on iPhone.
+    ///
+    /// If it doesn't exist, or the rootViewController's final child is not a UINavigationController, this will be nil.
+    var rightMostNavigationController: UINavigationController? {
+        return self.rootViewController?.children.last as? UINavigationController
+    }
+}
+


### PR DESCRIPTION
When attempting to navigate to an ExternalLink, we must be referring to the main 'detail' UINavigationController (on an iPhone this is the top-most one, while on an iPad this is the detail navigation controller). Currently, it is referring to a different navigation controller (and so is presenting the SFSafariViewController incorrectly).

This PR resolves this, by adding an extension to fetch the top-most detail navigation controller, and uses that to present the web view.