### PR TITLE
Fixes incorrect QuizAreaSelection image aspect ratio

### DIFF
--- a/ThunderCloud/QuizAreaSelectionViewController.swift
+++ b/ThunderCloud/QuizAreaSelectionViewController.swift
@@ -31,15 +31,23 @@ class QuizAreaSelectionViewController: UIViewController {
 		guard let question = question else {
 			return
 		}
-		
-		imageView.image = question.selectionImage
-		let imageAspect = question.selectionImage.size.height / question.selectionImage.size.width
-		heightConstraint.constant = imageAspect * imageView.frame.width
-		
+        
 		let imageAnalyser = ImageColorAnalyzer(image: question.selectionImage)
 		imageAnalyser.analyze()
 		circleColor = imageAnalyser.detailColor ?? .black
 	}
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        guard let question = question else {
+            return
+        }
+        
+        imageView.image = question.selectionImage
+        let imageAspect = question.selectionImage.size.height / question.selectionImage.size.width
+        heightConstraint.constant = imageAspect * imageView.frame.width
+    }
 	
 	@IBAction func handleTap(_ sender: UITapGestureRecognizer) {
 		


### PR DESCRIPTION
It was found that on iPad, when viewing a quiz question where an area within an image has to be selected, the image's aspect ratio would be incorrectly determined. This is as, the calculation occurred within `viewDidLoad`, where it had not yet been positioned & resized. This would result in the height being wildly out of proportion with the width, and correct answers would be resolved as being incorrect.

This is now resolved, by moving the aspect ratio calculations into `viewDidAppear(:)` so they occur once the view controller has been correctly positioned and resized.