### PR TITLE
Fixes content streaming failure

### DIFF
--- a/ThunderCloud/StreamingContentController.swift
+++ b/ThunderCloud/StreamingContentController.swift
@@ -308,10 +308,11 @@ class StreamingContentFileOperation: CustomOperationBase {
             return
         }
         
-        // `init` method requires a full path to the file to be downloaded so we don't provide a further path here!
-        fileRequestController.download("", progress: nil) { (response, fileLocation, error) in
+        // We provide `overrideURL` here because `RequestController.init(baseAddress:)` appends a `/` to the URL which isn't
+        // supported by s3 when downloading files!
+        fileRequestController.download(nil, overrideURL: URL(string: fileDownloadURLString)) { (response, fileLocation, error) in
+            
             if let fromLocation = fileLocation {
-                
                 let toLocation = self.targetFolderURL.appendingPathComponent(self.fileNameComponent)
                 try? FileManager.default.moveItem(at: fromLocation, to: toLocation)
             }


### PR DESCRIPTION
##  Description
Changes `StreamingContentController` to not rely on baseURL when downloading files because it appends a `/` to the url which fails the download!
Instead we use `overrideURL` on the `download` call

## Motivation and Context
Fixes streaming storm content pages

## How Has This Been Tested?
Has been tested manually as `StreamingContentController` currently isn't testable.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.