### PR TITLE
Fixes quiz text selection

### DIFF
--- a/ThunderCloud/QuizTextSelectionViewController.swift
+++ b/ThunderCloud/QuizTextSelectionViewController.swift
@@ -27,6 +27,7 @@ class QuizTextSelectionViewController: TableViewController {
         
         tableView.allowsMultipleSelection = question.limit > 1
         tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 44+32, right: 0)
+        clearsSelectionOnViewWillAppear = false
         
         let rows = question.options.enumerated().map { (index, option) -> Row in
             
@@ -42,16 +43,22 @@ class QuizTextSelectionViewController: TableViewController {
                 if boolValue {
                     
                     // If we've selected more answers than limit allows
-                    if question.limit > 1 && question.answer.count > question.limit - 1, let firstAnswer = question.answer.first {
+                    if question.answer.count > question.limit - 1, let lastAnswer = question.answer.last {
                         
                         // Deselect the last selected (No need to remove it from the question object as deselect handler will do this for us)
-                        let removeIndexPath = IndexPath(row: firstAnswer, section: 0)
+                        let removeIndexPath = IndexPath(row: lastAnswer, section: 0)
                         self.tableView.deselectRow(at: removeIndexPath, animated: false)
                         self.tableView(self.tableView, didDeselectRowAt: removeIndexPath)
-                    }
-                    
-                    // As long as it's not already selected
-                    if !question.answer.contains(index) {
+                        
+                        // If the row selected wasn't the same as the answer beforehand (Clicking the same item to deselect)
+                        // then add it to the question's answers
+                        if lastAnswer != index {
+                            question.answer.append(index)
+                        }
+
+                        // As long as it's not already selected
+
+                    } else if !question.answer.contains(index) {
                         question.answer.append(index)
                     }
                     

--- a/ThunderCloud/SingleSelectionTableViewCell.swift
+++ b/ThunderCloud/SingleSelectionTableViewCell.swift
@@ -16,4 +16,9 @@ class SingleSelectionTableViewCell: TableViewCell {
 	override func awakeFromNib() {
 		super.awakeFromNib()
 	}
+    
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+        checkView.set(on: selected, animated: true)
+    }
 }


### PR DESCRIPTION
## Description
Changes how quiz text item selection is handled to fix a couple of issues:
- Contrary to the comments and previous behaviour (Before swift re-write) the quiz was deselecting the **first** selected answer when over-selected as apposed to the most **recent**.
- A bug was present which caused the selected answer to be de-selected when popping back to a quiz screen, and due to the way selection is handled this caused UI bugs.

## Motivation and Context
Solves bugs noticed in the GDPC FA apps

## How Has This Been Tested?
I have tested this by making the changes in BRC First Aid which has the quiz logic copied locally for Storm overrides. I did this manually by clicking through the quizzes and making sure the UI updated correctly depending on what I pressed!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.