### PR TITLE
Fixes streaming pages content not rendering

### DIFF
--- a/ThunderCloud/ContentController.swift
+++ b/ThunderCloud/ContentController.swift
@@ -687,7 +687,7 @@ public class ContentController: NSObject {
             return false
         }
         
-        if (!self.fileExistsInBundle(file: "app.json")) {
+        if !self.fileExistsInBundle(file: "app.json") {
             
             os_log("%@", log: self.contentControllerLog, type: .error, ContentControllerError.missingAppJSON.localizedDescription)
 
@@ -696,7 +696,7 @@ public class ContentController: NSObject {
         }
         os_log("app.json exists", log: self.contentControllerLog, type: .debug)
         
-        if (!self.fileExistsInBundle(file: "manifest.json")) {
+        if !self.fileExistsInBundle(file: "manifest.json") {
             
             os_log("%@", log: self.contentControllerLog, type: .error, ContentControllerError.missingManifestJSON.localizedDescription)
 

--- a/ThunderCloud/ContentController.swift
+++ b/ThunderCloud/ContentController.swift
@@ -1122,6 +1122,15 @@ public extension ContentController {
         
         var bundleFile: URL?
         var cacheFile: URL?
+        var streamedFile: URL?
+        
+        if let streamedDirectory = StreamingPagesController.streamingCacheURL {
+            if let _inDirectory = inDirectory {
+                streamedFile = streamedDirectory.appendingPathComponent(_inDirectory).appendingPathComponent(forResource).appendingPathExtension(withExtension)
+            } else {
+                streamedFile = streamedDirectory.appendingPathComponent(forResource).appendingPathExtension(withExtension)
+            }
+        }
         
         if let bundleDirectory = bundleDirectory {
             
@@ -1141,7 +1150,9 @@ public extension ContentController {
             }
         }
         
-        if let _cacheFile = cacheFile, FileManager.default.fileExists(atPath: _cacheFile.path) {
+        if let _streamedFile = streamedFile, FileManager.default.fileExists(atPath: _streamedFile.path) {
+            return _streamedFile
+        } else if let _cacheFile = cacheFile, FileManager.default.fileExists(atPath: _cacheFile.path) {
             return _cacheFile
         } else if let _bundleFile = bundleFile, FileManager.default.fileExists(atPath: _bundleFile.path) {
             return _bundleFile
@@ -1175,6 +1186,17 @@ public extension ContentController {
     func fileNames(inDirectory: String) -> Set<String>? {
         
         var files: Set<String> = []
+        
+        if let streamDirectory = StreamingPagesController.streamingCacheURL {
+            
+            let filePathURL = streamDirectory.appendingPathComponent(inDirectory)
+            do {
+                let contents = try FileManager.default.contentsOfDirectory(atPath: filePathURL.path)
+                contents.forEach({ files.insert($0) })
+            } catch let error {
+                os_log("No files exist in streamed bundle directory subfolder: %@\nError: %@", log: self.contentControllerLog, type: .debug, inDirectory, error.localizedDescription)
+            }
+        }
         
         if let deltaDirectory = deltaDirectory {
             
@@ -1220,6 +1242,13 @@ public extension ContentController {
         if let bundleDirectory = bundleDirectory {
             let fileBundlePath = bundleDirectory.appendingPathComponent(file).path
             if (FileManager.default.fileExists(atPath: fileBundlePath)) {
+                return true
+            }
+        }
+        
+        if let streamDirectory = StreamingPagesController.streamingCacheURL {
+            let fileStreamedPath = streamDirectory.appendingPathComponent(file).path
+            if (FileManager.default.fileExists(atPath: fileStreamedPath)) {
                 return true
             }
         }

--- a/ThunderCloud/ContentController.swift
+++ b/ThunderCloud/ContentController.swift
@@ -1227,28 +1227,28 @@ public extension ContentController {
         
         if let temporaryUpdateDirectory = temporaryUpdateDirectory {
             let fileTemporaryCachePath = temporaryUpdateDirectory.appendingPathComponent(file).path
-            if (FileManager.default.fileExists(atPath: fileTemporaryCachePath)) {
+            if FileManager.default.fileExists(atPath: fileTemporaryCachePath) {
                 return true
             }
         }
         
         if let deltaDirectory = deltaDirectory {
             let fileCachePath = deltaDirectory.appendingPathComponent(file).path
-            if (FileManager.default.fileExists(atPath: fileCachePath)) {
+            if FileManager.default.fileExists(atPath: fileCachePath) {
                 return true
             }
         }
         
         if let bundleDirectory = bundleDirectory {
             let fileBundlePath = bundleDirectory.appendingPathComponent(file).path
-            if (FileManager.default.fileExists(atPath: fileBundlePath)) {
+            if FileManager.default.fileExists(atPath: fileBundlePath) {
                 return true
             }
         }
         
         if let streamDirectory = StreamingPagesController.streamingCacheURL {
             let fileStreamedPath = streamDirectory.appendingPathComponent(file).path
-            if (FileManager.default.fileExists(atPath: fileStreamedPath)) {
+            if FileManager.default.fileExists(atPath: fileStreamedPath) {
                 return true
             }
         }
@@ -1258,13 +1258,13 @@ public extension ContentController {
         
         // Because of the app thinner, files in the original content directory have been removed
         // And moved to the Bundle.xcassets, so lets check for them in there.
-        if let _lastUnderScoreComponent = lastUnderScoreComponent, (_lastUnderScoreComponent != thinnedAssetName) &&
+        if let _lastUnderScoreComponent = lastUnderScoreComponent, _lastUnderScoreComponent != thinnedAssetName &&
             (_lastUnderScoreComponent.contains(".png") || _lastUnderScoreComponent.contains(".jpg")) {
             
             thinnedAssetName = thinnedAssetName.replacingOccurrences(of: "_\(_lastUnderScoreComponent)", with: "")
         }
         
-        if (UIImage(named: thinnedAssetName) != nil) {
+        if UIImage(named: thinnedAssetName) != nil {
             return true
         }
         

--- a/ThunderCloud/DownloadingStormBundleViewController.swift
+++ b/ThunderCloud/DownloadingStormBundleViewController.swift
@@ -103,7 +103,7 @@ class DownloadProgress {
             let dt = t - lastReading.timeStamp
             let db = newValue - lastReading.downloaded
             
-            if (dt > sampleSpacing && db > 0) {
+            if dt > sampleSpacing && db > 0 {
                 
                 speeds.append((speed: Double(db)/dt, timeStamp: t))
                 speeds = speeds.filter({ (result) -> Bool in
@@ -291,7 +291,7 @@ class DownloadingStormBundleViewController: UIViewController {
                 
             } else if let progress = self?.downloadProgress {
                 
-                if (stage == .downloading) {
+                if stage == .downloading {
                     
                     OperationQueue.main.addOperation {
                         

--- a/ThunderCloud/StreamingContentController.swift
+++ b/ThunderCloud/StreamingContentController.swift
@@ -118,7 +118,7 @@ public class StreamingPagesController: NSObject {
                 return fileArray.compactMap({ (fileDictionary: [AnyHashable : Any]) -> URL? in
                     
                     if let urlString = fileDictionary["src"] as? String {
-                        if (isExcluded(fileURLString: urlString)){
+                        if isExcluded(fileURLString: urlString) {
                             return nil
                         }
                         return fullURL(from: urlString)

--- a/ThunderCloud/StreamingContentController.swift
+++ b/ThunderCloud/StreamingContentController.swift
@@ -18,7 +18,13 @@ public class StreamingPagesController: NSObject {
     
     let downloadQueue = OperationQueue()
     
-    var streamingCacheURL: URL?
+    static var streamingCacheURL: URL? = {
+        let fileManager = FileManager.default
+        guard let tmpURL = try? fileManager.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: false) else {
+            return nil
+        }
+        return tmpURL.appendingPathComponent("Streaming")
+    }()
     
     override init() {
         
@@ -38,19 +44,16 @@ public class StreamingPagesController: NSObject {
     func setupDirectories() {
         
         let fileManager = FileManager.default
-        if let tmpURL = try? fileManager.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true) {
+        if let tmpURL = StreamingPagesController.streamingCacheURL {
             
-            let finalURL = tmpURL.appendingPathComponent("Streaming")
-            let pagesURL = finalURL.appendingPathComponent("pages")
-            let contentURL = finalURL.appendingPathComponent("content")
-            let languageURL = finalURL.appendingPathComponent("languages")
+            let pagesURL = tmpURL.appendingPathComponent("pages")
+            let contentURL = tmpURL.appendingPathComponent("content")
+            let languageURL = tmpURL.appendingPathComponent("languages")
             
-            try? fileManager.createDirectory(at: finalURL, withIntermediateDirectories: true, attributes: nil)
+            try? fileManager.createDirectory(at: tmpURL, withIntermediateDirectories: true, attributes: nil)
             try? fileManager.createDirectory(at: pagesURL, withIntermediateDirectories: true, attributes: nil)
             try? fileManager.createDirectory(at: contentURL, withIntermediateDirectories: true, attributes: nil)
             try? fileManager.createDirectory(at: languageURL, withIntermediateDirectories: true, attributes: nil)
-            
-            streamingCacheURL = finalURL
         }
     }
     
@@ -170,7 +173,7 @@ public class StreamingPagesController: NSObject {
             
             var fileOperations = [StreamingContentFileOperation]()
             
-            if let _files = files, let _toDirectory = self.streamingCacheURL {
+            if let _files = files, let _toDirectory = StreamingPagesController.streamingCacheURL {
                 
                 for file in _files {
                     
@@ -181,7 +184,7 @@ public class StreamingPagesController: NSObject {
                 }
             }
             
-            if let _toDirectory = self.streamingCacheURL {
+            if let _toDirectory = StreamingPagesController.streamingCacheURL {
                 
                 //Get language
                 if let _languageString = StormLanguageController.shared.currentLanguage {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Makes sure that the streamed bundle is checked when pulling content using ContentController, as otherwise the app relies on having that content in a bundle or delta update.

We have exposed the directory that `StreamingPagesController` saves data to, and added checks to all content methods in `ContentController` to check said directory for content as well as the delta and original bundle directory!

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #170 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Has been tested in ARC First Aid manually by calling the code in the attached issue.

## Screenshots (if appropriate):

### Before
![Simulator Screen Shot - iPhone 6 - 2019-08-06 at 14 52 40](https://user-images.githubusercontent.com/9033831/62606753-c5b4c400-b8f4-11e9-93d2-7f0dfd4a81ec.png)

### After
![Simulator Screen Shot - iPhone 6 - 2019-08-06 at 15 19 50](https://user-images.githubusercontent.com/9033831/62606777-cf3e2c00-b8f4-11e9-8f0f-635d691fc4b3.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
