### PR TITLE
Fixes boolean logic around standard list item link classes!

### DIFF
--- a/ThunderCloud/StandardListItem.swift
+++ b/ThunderCloud/StandardListItem.swift
@@ -18,7 +18,7 @@ open class StandardListItem: ListItem {
 				return url.absoluteString.isEmpty ? UITableViewCell.AccessoryType.none : .disclosureIndicator
 			}
 			
-			guard let linkClass = link?.linkClass, linkClass == .sms, linkClass == .emergency, linkClass == .share, linkClass == .timer else { return UITableViewCell.AccessoryType.none }
+			guard let linkClass = link?.linkClass, linkClass == .sms || linkClass == .emergency || linkClass == .share || linkClass == .timer else { return UITableViewCell.AccessoryType.none }
 			
 			return .disclosureIndicator
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This updates disclosure indicator logic on StandardListItem to match that from Obj-C version

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Solves disclosure indicators not being shown when they should be!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Has been tested by using this commit locally for BRC First Aid

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
