### PR TITLE
Image accessibility labels

### DIFF
--- a/ThunderCloud.xcodeproj/project.pbxproj
+++ b/ThunderCloud.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		B1B046A91F0F81A400FD2FA7 /* LogoListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B046A81F0F81A400FD2FA7 /* LogoListItemView.swift */; };
 		B1B046AB1F0F84EE00FD2FA7 /* AnimationListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B046AA1F0F84EE00FD2FA7 /* AnimationListItem.swift */; };
 		B1B046AD1F0F896900FD2FA7 /* AnimationListItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B046AC1F0F896900FD2FA7 /* AnimationListItemCell.swift */; };
+		B1B7035B230416F500FFAA03 /* StormImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B7035A230416F500FFAA03 /* StormImage.swift */; };
 		B1B8F4BC21B5832C00BB1AFB /* AppScrollerItemViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B8F4BB21B5832C00BB1AFB /* AppScrollerItemViewCell.swift */; };
 		B1BAAC2322253D7A007F0F61 /* NavigationController+Conformance.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1BAAC2222253D7A007F0F61 /* NavigationController+Conformance.swift */; };
 		B1BAAC2522254083007F0F61 /* ThunderCloud.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = C284D46F19C83FC600DA5EE3 /* ThunderCloud.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -463,6 +464,7 @@
 		B1B046A81F0F81A400FD2FA7 /* LogoListItemView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogoListItemView.swift; sourceTree = "<group>"; };
 		B1B046AA1F0F84EE00FD2FA7 /* AnimationListItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationListItem.swift; sourceTree = "<group>"; };
 		B1B046AC1F0F896900FD2FA7 /* AnimationListItemCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationListItemCell.swift; sourceTree = "<group>"; };
+		B1B7035A230416F500FFAA03 /* StormImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StormImage.swift; sourceTree = "<group>"; };
 		B1B8F4BB21B5832C00BB1AFB /* AppScrollerItemViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppScrollerItemViewCell.swift; sourceTree = "<group>"; };
 		B1BAAC2222253D7A007F0F61 /* NavigationController+Conformance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NavigationController+Conformance.swift"; sourceTree = "<group>"; };
 		B1BAAD0F2226A67F007F0F61 /* LocalisationLocaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalisationLocaleTests.swift; sourceTree = "<group>"; };
@@ -646,6 +648,7 @@
 				B1163E7A1F0CF86A00A9E8E2 /* HeaderListItem.swift */,
 				B1163E7C1F0CF97E00A9E8E2 /* HeaderListItemCell.swift */,
 				B1163E7E1F0CF99A00A9E8E2 /* HeaderListItemCell.xib */,
+				B1B7035A230416F500FFAA03 /* StormImage.swift */,
 				B13DE0BF1F0CFE2500C6B9B7 /* ImageListItem.swift */,
 				C284D49019C8400D00DA5EE3 /* StormAssets.xcassets */,
 				B163D2061FB05B8700BF4CEC /* ImageRepresentation.swift */,
@@ -1334,6 +1337,7 @@
 				B1B046A11F0E87B700FD2FA7 /* Localisation.swift in Sources */,
 				C284D64E19C8400E00DA5EE3 /* untar.c in Sources */,
 				B10832691F0BD462008B565D /* OrderedListItem.swift in Sources */,
+				B1B7035B230416F500FFAA03 /* StormImage.swift in Sources */,
 				B1B0469F1F0E85AD00FD2FA7 /* LocalisationLanguage.swift in Sources */,
 				B1B046991F0E815000FD2FA7 /* CollectionListItemView.swift in Sources */,
 				B179EC2C1F0FA3350007ED3F /* MultiVideoListItemView.swift in Sources */,

--- a/ThunderCloud/AccordionTabBarViewController.swift
+++ b/ThunderCloud/AccordionTabBarViewController.swift
@@ -208,6 +208,9 @@ open class AccordionTabBarViewController: TableViewController, StormObjectProtoc
 				}
 				
 				navTabController.tabBarItem.image = StormGenerator.image(fromJSON: tabBarItemDict["image"])
+                if let imageDict = tabBarItemDict["image"] as? [AnyHashable : Any], let accessibilityLabelDict = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
+                    navTabController.tabBarItem.accessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
+                }
 				
 				if let title = tabBarItemDict["title"] as? [AnyHashable : Any] {
 					navTabController.title = StormLanguageController.shared.string(for: title)
@@ -233,6 +236,9 @@ open class AccordionTabBarViewController: TableViewController, StormObjectProtoc
 				}
 				
 				viewController.tabBarItem.image = StormGenerator.image(fromJSON: tabBarItemDict["image"])
+                if let imageDict = tabBarItemDict["image"] as? [AnyHashable : Any], let accessibilityLabelDict = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
+                    viewController.tabBarItem.accessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
+                }
 				
 				viewControllers.append(viewController)
 				viewControllersShouldDisplayNavigationBar.append(false)

--- a/ThunderCloud/AccordionTabBarViewController.swift
+++ b/ThunderCloud/AccordionTabBarViewController.swift
@@ -10,127 +10,127 @@ import UIKit
 import ThunderTable
 
 class ScrollDisabledTableView: UITableView {
-	
-	override func scrollRectToVisible(_ rect: CGRect, animated: Bool) {
-		
-	}
-	
-	override var contentOffset: CGPoint {
-		get {
-			return super.contentOffset
-		}
-		set {
-			
-		}
-	}
+    
+    override func scrollRectToVisible(_ rect: CGRect, animated: Bool) {
+        
+    }
+    
+    override var contentOffset: CGPoint {
+        get {
+            return super.contentOffset
+        }
+        set {
+            
+        }
+    }
 }
 
 public class AccordionTabBarItem: Row {
-	
-	public var title: String? {
-		return viewController.tabBarItem.title
-	}
-	
-	public var image: UIImage? {
-		get {
-			return viewController.tabBarItem.image?.withRenderingMode(.alwaysTemplate)
-		}
-		set {
-			
-		}
-	}
-	
-	private var searchBar: UISearchBar? {
-		
-		if #available(iOS 11, *) {
-			return viewController.navigationItem.searchController?.searchBar
-		}
-		
-		return nil
-	}
-	
-	private var titleView: UIView? {
-		return viewController.navigationItem.titleView
-	}
-	
-	let viewController: UIViewController
-	
-	public init(viewController: UIViewController) {
-		
-		self.viewController = viewController
-	}
-	
-	public var remainingHeight: CGFloat = 0
-	
-	private var viewControllerHeight: CGFloat {
-		return searchBar != nil ? remainingHeight - 56 : (titleView != nil ? remainingHeight - 44 : remainingHeight)
-	}
-	
-	public var expanded: Bool = false
-	
-	public var isFirstItem: Bool = false
-	
-	public func height(constrainedTo size: CGSize, in tableView: UITableView) -> CGFloat? {
-		let height = expanded ? remainingHeight + 44 : 44
-		return isFirstItem ? height + 20 : height
-	}
-	
-	public var cellClass: UITableViewCell.Type? {
-		return AccordionTabBarItemTableViewCell.self
-	}
-	
-	public func configure(cell: UITableViewCell, at indexPath: IndexPath, in tableViewController: TableViewController) {
-		
-		guard let accordionCell = cell as? AccordionTabBarItemTableViewCell else { return }
-		
-		viewController.view.frame = expanded ? accordionCell.viewControllerView.bounds : .zero
-		
-		accordionCell.cellImageView?.isHidden = image == nil
-		
-		var backgroundColor = ThemeManager.shared.theme.secondaryColor
-		let contrastingColor = expanded || isFirstItem ? ThemeManager.shared.theme.primaryLabelColor.contrasting : ThemeManager.shared.theme.secondaryColor.contrasting
-		
-		if expanded {
-			backgroundColor = isFirstItem ? .clear : ThemeManager.shared.theme.mainColor
-		} else if isFirstItem {
-			backgroundColor = .clear
-		}
-		
-		accordionCell.backgroundColor = backgroundColor
-		accordionCell.contentView.backgroundColor = backgroundColor
-		accordionCell.cellTextLabel?.textColor = contrastingColor
-		accordionCell.cellImageView?.tintColor = contrastingColor
-		
-		accordionCell.topConstraint.constant = isFirstItem ? 28 : 8
-		
-		accordionCell.viewControllerView.subviews.forEach { (view) in
-			view.removeFromSuperview()
-		}
-		accordionCell.customTitleView.subviews.forEach { (view) in
-			view.removeFromSuperview()
-		}
-		
-		accordionCell.customTitleHeightConstraint.constant = searchBar != nil ? 44 + 12 : (titleView != nil ? 44 : 0)
-		
-		viewController.view.frame = accordionCell.viewControllerView.bounds
-		
-		guard expanded else { return }
-		
-		accordionCell.viewControllerView.addSubview(viewController.view)
-		
-		guard let titleView = titleView ?? searchBar else { return }
-		
-		titleView.translatesAutoresizingMaskIntoConstraints = false
-		accordionCell.customTitleView.addSubview(titleView)
-		
-		let viewsDict = ["view": titleView]
-		accordionCell.customTitleView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-0-[view]-0-|", options: [], metrics: nil, views: viewsDict))
-		accordionCell.customTitleView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|-0-[view]-0-|", options: [], metrics: nil, views: viewsDict))
-	}
-	
-	public var accessoryType: UITableViewCell.AccessoryType? {
-		return UITableViewCell.AccessoryType.none
-	}
+    
+    public var title: String? {
+        return viewController.tabBarItem.title
+    }
+    
+    public var image: UIImage? {
+        get {
+            return viewController.tabBarItem.image?.withRenderingMode(.alwaysTemplate)
+        }
+        set {
+            
+        }
+    }
+    
+    private var searchBar: UISearchBar? {
+        
+        if #available(iOS 11, *) {
+            return viewController.navigationItem.searchController?.searchBar
+        }
+        
+        return nil
+    }
+    
+    private var titleView: UIView? {
+        return viewController.navigationItem.titleView
+    }
+    
+    let viewController: UIViewController
+    
+    public init(viewController: UIViewController) {
+        
+        self.viewController = viewController
+    }
+    
+    public var remainingHeight: CGFloat = 0
+    
+    private var viewControllerHeight: CGFloat {
+        return searchBar != nil ? remainingHeight - 56 : (titleView != nil ? remainingHeight - 44 : remainingHeight)
+    }
+    
+    public var expanded: Bool = false
+    
+    public var isFirstItem: Bool = false
+    
+    public func height(constrainedTo size: CGSize, in tableView: UITableView) -> CGFloat? {
+        let height = expanded ? remainingHeight + 44 : 44
+        return isFirstItem ? height + 20 : height
+    }
+    
+    public var cellClass: UITableViewCell.Type? {
+        return AccordionTabBarItemTableViewCell.self
+    }
+    
+    public func configure(cell: UITableViewCell, at indexPath: IndexPath, in tableViewController: TableViewController) {
+        
+        guard let accordionCell = cell as? AccordionTabBarItemTableViewCell else { return }
+        
+        viewController.view.frame = expanded ? accordionCell.viewControllerView.bounds : .zero
+        
+        accordionCell.cellImageView?.isHidden = image == nil
+        
+        var backgroundColor = ThemeManager.shared.theme.secondaryColor
+        let contrastingColor = expanded || isFirstItem ? ThemeManager.shared.theme.primaryLabelColor.contrasting : ThemeManager.shared.theme.secondaryColor.contrasting
+        
+        if expanded {
+            backgroundColor = isFirstItem ? .clear : ThemeManager.shared.theme.mainColor
+        } else if isFirstItem {
+            backgroundColor = .clear
+        }
+        
+        accordionCell.backgroundColor = backgroundColor
+        accordionCell.contentView.backgroundColor = backgroundColor
+        accordionCell.cellTextLabel?.textColor = contrastingColor
+        accordionCell.cellImageView?.tintColor = contrastingColor
+        
+        accordionCell.topConstraint.constant = isFirstItem ? 28 : 8
+        
+        accordionCell.viewControllerView.subviews.forEach { (view) in
+            view.removeFromSuperview()
+        }
+        accordionCell.customTitleView.subviews.forEach { (view) in
+            view.removeFromSuperview()
+        }
+        
+        accordionCell.customTitleHeightConstraint.constant = searchBar != nil ? 44 + 12 : (titleView != nil ? 44 : 0)
+        
+        viewController.view.frame = accordionCell.viewControllerView.bounds
+        
+        guard expanded else { return }
+        
+        accordionCell.viewControllerView.addSubview(viewController.view)
+        
+        guard let titleView = titleView ?? searchBar else { return }
+        
+        titleView.translatesAutoresizingMaskIntoConstraints = false
+        accordionCell.customTitleView.addSubview(titleView)
+        
+        let viewsDict = ["view": titleView]
+        accordionCell.customTitleView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|-0-[view]-0-|", options: [], metrics: nil, views: viewsDict))
+        accordionCell.customTitleView.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|-0-[view]-0-|", options: [], metrics: nil, views: viewsDict))
+    }
+    
+    public var accessoryType: UITableViewCell.AccessoryType? {
+        return UITableViewCell.AccessoryType.none
+    }
 }
 
 /// A subvlass of `UIViewController` which replaces `UITabBarController`.
@@ -138,338 +138,338 @@ public class AccordionTabBarItem: Row {
 /// When a cell is selected the `UIViewController` for the selected tab is expanded underneath the item's cell and all other "tabs" are minimised. By default the top item is automatically expanded.
 /// This is best used on iPad for displaying tabbed content in the master portion of a `UISplitViewController`
 open class AccordionTabBarViewController: TableViewController, StormObjectProtocol {
-	
-	/// An array of tab bar items that are being shown
-	open var tabBarItems: [AccordionTabBarItem] = []
-	
-	/// An array of `UIViewController`s each 'attached' to an individual `AccordionTabBarItem`
-	open var viewControllers: [UIViewController] = []
-	
-	/// The currently displayed (Expanded) `UIViewController`
-	open var selectedViewController: UIViewController? {
-		guard let selectedTabIndex = selectedTabIndex, selectedTabIndex < viewControllers.count else {
-			return nil
-		}
-		return viewControllers[selectedTabIndex]
-	}
-	
-	/// The currently selected tab index
-	open var selectedTabIndex: Int? = 0
-	
-	private var placeholders: [Placeholder] = []
-	
-	private var viewControllersShouldDisplayNavigationBar: [Bool] = []
-	
-	open override func loadView() {
-		
-		tableView = ScrollDisabledTableView(frame: UIScreen.main.bounds, style: .grouped)
-		tableView.delegate = self
-		tableView.dataSource = self
-		view = tableView
-	}
-	
-	//MARK: -
-	//MARK: - View Lifecycle
-	
-	public required init(dictionary: [AnyHashable : Any]) {
-		
-		super.init(style: .grouped)
-		
-		automaticallyAdjustsScrollViewInsets = false
-		edgesForExtendedLayout = .all
-		extendedLayoutIncludesOpaqueBars = true
-		navigationController?.automaticallyAdjustsScrollViewInsets = false
-		
-		// Load root storm pages
-		guard let pageDictionaries = dictionary["pages"] as? [[AnyHashable : Any]] else {
-			return
-		}
-		
-		pageDictionaries.forEach { (pageDictionary) in
-			
-			guard let tabBarItemDict = pageDictionary["tabBarItem"] as? [AnyHashable : Any] else { return }
-			
-			placeholders.append(Placeholder(dictionary: tabBarItemDict))
-			
-			if let pageType = pageDictionary["type"] as? String, pageType == "TabbedPageCollection" {
-				
-				var pageTypeDictionary = pageDictionary
-				// Not sure entirely why this happens
-				pageTypeDictionary["type"] = "NavigationTabBarViewController"
-				
-				guard let tabViewControllerClass = StormObjectFactory.shared.class(for: NSStringFromClass(NavigationTabBarViewController.self)) as? StormObjectProtocol.Type else {
-					print("[TabbedPageCollection] Please make sure your override for TSCNavigationTabBarViewController conforms to StormObjectProtocol")
-					return
-				}
-				
-				guard let navTabController = tabViewControllerClass.init(dictionary: pageTypeDictionary) as? UIViewController else {
-					print("[TabbedPageCollection] Please make sure your override for TSCNavigationTabBarViewController is a subclass of UIViewController")
-					return
-				}
-				
-				navTabController.tabBarItem.image = StormGenerator.image(fromJSON: tabBarItemDict["image"])
+    
+    /// An array of tab bar items that are being shown
+    open var tabBarItems: [AccordionTabBarItem] = []
+    
+    /// An array of `UIViewController`s each 'attached' to an individual `AccordionTabBarItem`
+    open var viewControllers: [UIViewController] = []
+    
+    /// The currently displayed (Expanded) `UIViewController`
+    open var selectedViewController: UIViewController? {
+        guard let selectedTabIndex = selectedTabIndex, selectedTabIndex < viewControllers.count else {
+            return nil
+        }
+        return viewControllers[selectedTabIndex]
+    }
+    
+    /// The currently selected tab index
+    open var selectedTabIndex: Int? = 0
+    
+    private var placeholders: [Placeholder] = []
+    
+    private var viewControllersShouldDisplayNavigationBar: [Bool] = []
+    
+    open override func loadView() {
+        
+        tableView = ScrollDisabledTableView(frame: UIScreen.main.bounds, style: .grouped)
+        tableView.delegate = self
+        tableView.dataSource = self
+        view = tableView
+    }
+    
+    //MARK: -
+    //MARK: - View Lifecycle
+    
+    public required init(dictionary: [AnyHashable : Any]) {
+        
+        super.init(style: .grouped)
+        
+        automaticallyAdjustsScrollViewInsets = false
+        edgesForExtendedLayout = .all
+        extendedLayoutIncludesOpaqueBars = true
+        navigationController?.automaticallyAdjustsScrollViewInsets = false
+        
+        // Load root storm pages
+        guard let pageDictionaries = dictionary["pages"] as? [[AnyHashable : Any]] else {
+            return
+        }
+        
+        pageDictionaries.forEach { (pageDictionary) in
+            
+            guard let tabBarItemDict = pageDictionary["tabBarItem"] as? [AnyHashable : Any] else { return }
+            
+            placeholders.append(Placeholder(dictionary: tabBarItemDict))
+            
+            if let pageType = pageDictionary["type"] as? String, pageType == "TabbedPageCollection" {
+                
+                var pageTypeDictionary = pageDictionary
+                // Not sure entirely why this happens
+                pageTypeDictionary["type"] = "NavigationTabBarViewController"
+                
+                guard let tabViewControllerClass = StormObjectFactory.shared.class(for: NSStringFromClass(NavigationTabBarViewController.self)) as? StormObjectProtocol.Type else {
+                    print("[TabbedPageCollection] Please make sure your override for TSCNavigationTabBarViewController conforms to StormObjectProtocol")
+                    return
+                }
+                
+                guard let navTabController = tabViewControllerClass.init(dictionary: pageTypeDictionary) as? UIViewController else {
+                    print("[TabbedPageCollection] Please make sure your override for TSCNavigationTabBarViewController is a subclass of UIViewController")
+                    return
+                }
+                
+                navTabController.tabBarItem.image = StormGenerator.image(fromJSON: tabBarItemDict["image"])
                 if let imageDict = tabBarItemDict["image"] as? [AnyHashable : Any], let accessibilityLabelDict = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
                     navTabController.tabBarItem.accessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
                 }
-				
-				if let title = tabBarItemDict["title"] as? [AnyHashable : Any] {
-					navTabController.title = StormLanguageController.shared.string(for: title)
-				}
-
-				viewControllers.append(navTabController)
-				viewControllersShouldDisplayNavigationBar.append(false)
-				
-			} else {
-				
-				guard let pageSource = pageDictionary["src"] as? String, let pageURL = URL(string: pageSource) else {
-					print("[TabbedPageCollection] Failed to allocate view controller as no (or invalid) src present")
-					return
-				}
-				
-				guard let viewController = StormGenerator.viewController(URL: pageURL) else {
-					print("[TabbedPageCollection] Failed to allocate view controller at \(pageURL)")
-					return
-				}
-				
-				if let title = tabBarItemDict["title"] as? [AnyHashable : Any] {
-					viewController.tabBarItem.title = StormLanguageController.shared.string(for: title)
-				}
-				
-				viewController.tabBarItem.image = StormGenerator.image(fromJSON: tabBarItemDict["image"])
+                
+                if let title = tabBarItemDict["title"] as? [AnyHashable : Any] {
+                    navTabController.title = StormLanguageController.shared.string(for: title)
+                }
+                
+                viewControllers.append(navTabController)
+                viewControllersShouldDisplayNavigationBar.append(false)
+                
+            } else {
+                
+                guard let pageSource = pageDictionary["src"] as? String, let pageURL = URL(string: pageSource) else {
+                    print("[TabbedPageCollection] Failed to allocate view controller as no (or invalid) src present")
+                    return
+                }
+                
+                guard let viewController = StormGenerator.viewController(URL: pageURL) else {
+                    print("[TabbedPageCollection] Failed to allocate view controller at \(pageURL)")
+                    return
+                }
+                
+                if let title = tabBarItemDict["title"] as? [AnyHashable : Any] {
+                    viewController.tabBarItem.title = StormLanguageController.shared.string(for: title)
+                }
+                
+                viewController.tabBarItem.image = StormGenerator.image(fromJSON: tabBarItemDict["image"])
                 if let imageDict = tabBarItemDict["image"] as? [AnyHashable : Any], let accessibilityLabelDict = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
                     viewController.tabBarItem.accessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
                 }
-				
-				viewControllers.append(viewController)
-				viewControllersShouldDisplayNavigationBar.append(false)
-			}
-		}
-	}
-	
-	public required init?(coder aDecoder: NSCoder) {
-		super.init(coder: aDecoder)
-	}
-	
-	override open func viewDidLoad() {
-		
-		super.viewDidLoad()
-		
-		tableView.separatorStyle = .singleLine
-		tableView.separatorColor = UIColor.white.withAlphaComponent(0.4)
-		tableView.showsVerticalScrollIndicator = false
-		
-		tableView.tableHeaderView = UIView(frame: CGRect(x: 0, y: 0, width: 0.01, height: 0.01))
-		tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: 0.01, height: 0.01))
-		tableView.bounces = false
-		tableView.isScrollEnabled = false
-		view.backgroundColor = .clear
-		navigationController?.view.backgroundColor = .groupTableViewBackground
-		
-		tableView.contentInset = .zero
-		
-		tabBarItems = viewControllers.map({ (viewController) -> AccordionTabBarItem in
-			return AccordionTabBarItem(viewController: viewController)
-		})
-	
-		showPlaceholderViewController()
-		redraw()
-		
-		guard let firstViewController = viewControllers.first else { return }
-		
-		firstViewController.willMove(toParent: self)
-		addChild(firstViewController)
-		firstViewController.didMove(toParent: self)
-	}
-	
-	private var hasAppearedBefore = false
-	
-	override open func viewWillAppear(_ animated: Bool) {
-		
-		super.viewWillAppear(animated)
-		
-		// Don't want to show placeholder here otherwise views are stripped off-screen
-		// when the user shows/hides the accordion popover
-		if !hasAppearedBefore {
-			showPlaceholderViewController()
-		}
-		
-		hasAppearedBefore = true
-		
-		navigationController?.setNavigationBarHidden(false, animated: false)
-		
-		// Needs to be done here for portait view errors
-		extendedLayoutIncludesOpaqueBars = true
-		
-		guard let navigationController = navigationController else { return }
-		navigationController.view.sendSubviewToBack(navigationController.navigationBar)
-	}
-	
-	open override func viewDidAppear(_ animated: Bool) {
-		
-		super.viewDidAppear(animated)
-		
-		guard let navigationController = navigationController else { return }
-		
-		navigationController.view.sendSubviewToBack(navigationController.navigationBar)
-	}
-	
-	open override func viewDidLayoutSubviews() {
-		
-		super.viewDidLayoutSubviews()
-		
-		guard let navigationController = navigationController else { return }
-		navigationController.view.sendSubviewToBack(navigationController.navigationBar)
-		
-		let remainingHeight = view.frame.height - (CGFloat(tabBarItems.count) * 44.0) - tableView.contentInset.top - 20
-		
-		// Make sure to resize when rotate and remaining height changes!
-		if remainingHeight != tabBarItems.first?.remainingHeight {
-			
-			tabBarItems.enumerated().forEach { (index, tabItem) in
-				tabItem.remainingHeight = remainingHeight
-			}
-			
-			if let selectedIndex = selectedTabIndex, tabBarItems[selectedIndex].expanded {
-				tableView.reloadRows(at: [IndexPath(row: selectedIndex, section: 0)], with: .automatic)
-			}
-		}
-		
-		if tableView.contentInset == .zero {
-			
-			tableView.clipsToBounds = false
-			tableView.contentInset = .zero
-		}
-	}
-	
-	//MARK: -
-	//MARK: - Drawing
-	
-	private func redraw() {
-		
-		let remainingHeight = view.frame.height - (CGFloat(tabBarItems.count) * 44.0) - tableView.contentInset.top - 20
-		
-		tabBarItems.enumerated().forEach { (index, tabItem) in
-			tabItem.expanded = index == selectedTabIndex
-			tabItem.remainingHeight = remainingHeight
-			tabItem.isFirstItem = index == 0
-		}
-
-		let tabSection = TableSection(rows: tabBarItems, header: nil, footer: nil) { (row, selected, indexPath, tableView) -> (Void) in
-			
-			guard let tabItem = row as? AccordionTabBarItem else { return }
-			
-			// Set selected tab and then show placeholder view controller
-			self.selectedTabIndex = indexPath.row
-			self.showPlaceholderViewController()
-			
-			// Index paths to redraw
-			var redrawIndexPaths: [IndexPath] = [indexPath]
-			
-			var previousViewController: UIViewController?
-			
-			// Order of this line and line where we toggle the selected items expanded is important as we want to close the selected
-			// row before toggling the one which was just selected!
-			if let selectedIndex = self.tabBarItems.enumerated().first(where: { $0.1.expanded }), indexPath.row != selectedIndex.offset {
-				
-				previousViewController = selectedIndex.element.viewController
-				redrawIndexPaths.append(IndexPath(row: selectedIndex.offset, section: 0))
-				selectedIndex.element.expanded = false
-			}
-			
-			// If was previously expanded it's view controller will be hidden
-			if tabItem.expanded {
-				previousViewController = tabItem.viewController
-			}
-			
-			tabItem.expanded = !tabItem.expanded
-			
-			// If we've expanded a view controller
-			if tabItem.expanded {
-				tabItem.viewController.willMove(toParent: self)
-			} else {
-				self.selectedTabIndex = nil
-			}
-			
-			// View will move to logic!
-			previousViewController?.willMove(toParent: nil)
-			tableView.reloadRows(at: redrawIndexPaths, with: .automatic)
-			
-			previousViewController?.removeFromParent()
-			previousViewController?.didMove(toParent: nil)
-			
-			if tabItem.expanded {
-				
-				// Make sure to add child view controller!
-				self.addChild(tabItem.viewController)
-				tabItem.viewController.didMove(toParent: self)
-				
-				// Must do this otherwise pushing into details view doesn't work on tab > 0
-				if let listPage = tabItem.viewController as? ListPage {
-					listPage.data = listPage.data
-				}
-			}
-		}
-		
-		data = [tabSection]
-	}
-	
-	//MARK: -
-	//MARK: - Helpers
-	
-	private func showPlaceholderViewController() {
-		
-		guard UI_USER_INTERFACE_IDIOM() == .pad, let selectedTabIndex = selectedTabIndex, selectedTabIndex < placeholders.count else { return }
-		
-		var splitViewController: SplitViewController?
-		
-		if let applicationWindow = UIApplication.shared.keyWindow {
-			splitViewController = applicationWindow.rootViewController as? SplitViewController
-			// This is gross.. because window is `UIWindow??` on app delegate for some reason...
-		} else if let delegateWindow = UIApplication.shared.delegate?.window ?? nil {
-			splitViewController = delegateWindow.rootViewController as? SplitViewController
-		}
-		
-		guard let _splitViewController = splitViewController else {
-			return
-		}
-		
-		let placeholder = placeholders[selectedTabIndex]
-		
-		let placeholderVC = PlaceholderViewController(placeholder: placeholder)
-		
-		_splitViewController.detailViewController = UINavigationController(rootViewController: placeholderVC)
-	}
-	
-	//MARK: -
-	//MARK: - UITableViewDataSource
-	
-	override open func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-		
-		guard indexPath.row < tabBarItems.count else {
-			return super.tableView(tableView, heightForRowAt: indexPath)
-		}
-		
-		let tabItem = tabBarItems[indexPath.row]
-		
-		return tabItem.height(constrainedTo: .zero, in: tableView) ?? super.tableView(tableView, heightForRowAt: indexPath)
-	}
-	
-	override open func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-		
-		guard indexPath.row < tabBarItems.count else {
-			return super.tableView(tableView, estimatedHeightForRowAt: indexPath)
-		}
-		
-		let tabItem = tabBarItems[indexPath.row]
-		
-		return tabItem.height(constrainedTo: .zero, in: tableView) ?? super.tableView(tableView, estimatedHeightForRowAt: indexPath)
-	}
-	
-	// We have to override this to fix it being set to false when iPad is in portrait
-	open override var extendedLayoutIncludesOpaqueBars: Bool {
-		get {
-			return true
-		}
-		set {}
-	}
+                
+                viewControllers.append(viewController)
+                viewControllersShouldDisplayNavigationBar.append(false)
+            }
+        }
+    }
+    
+    public required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    override open func viewDidLoad() {
+        
+        super.viewDidLoad()
+        
+        tableView.separatorStyle = .singleLine
+        tableView.separatorColor = UIColor.white.withAlphaComponent(0.4)
+        tableView.showsVerticalScrollIndicator = false
+        
+        tableView.tableHeaderView = UIView(frame: CGRect(x: 0, y: 0, width: 0.01, height: 0.01))
+        tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: 0.01, height: 0.01))
+        tableView.bounces = false
+        tableView.isScrollEnabled = false
+        view.backgroundColor = .clear
+        navigationController?.view.backgroundColor = .groupTableViewBackground
+        
+        tableView.contentInset = .zero
+        
+        tabBarItems = viewControllers.map({ (viewController) -> AccordionTabBarItem in
+            return AccordionTabBarItem(viewController: viewController)
+        })
+        
+        showPlaceholderViewController()
+        redraw()
+        
+        guard let firstViewController = viewControllers.first else { return }
+        
+        firstViewController.willMove(toParent: self)
+        addChild(firstViewController)
+        firstViewController.didMove(toParent: self)
+    }
+    
+    private var hasAppearedBefore = false
+    
+    override open func viewWillAppear(_ animated: Bool) {
+        
+        super.viewWillAppear(animated)
+        
+        // Don't want to show placeholder here otherwise views are stripped off-screen
+        // when the user shows/hides the accordion popover
+        if !hasAppearedBefore {
+            showPlaceholderViewController()
+        }
+        
+        hasAppearedBefore = true
+        
+        navigationController?.setNavigationBarHidden(false, animated: false)
+        
+        // Needs to be done here for portait view errors
+        extendedLayoutIncludesOpaqueBars = true
+        
+        guard let navigationController = navigationController else { return }
+        navigationController.view.sendSubviewToBack(navigationController.navigationBar)
+    }
+    
+    open override func viewDidAppear(_ animated: Bool) {
+        
+        super.viewDidAppear(animated)
+        
+        guard let navigationController = navigationController else { return }
+        
+        navigationController.view.sendSubviewToBack(navigationController.navigationBar)
+    }
+    
+    open override func viewDidLayoutSubviews() {
+        
+        super.viewDidLayoutSubviews()
+        
+        guard let navigationController = navigationController else { return }
+        navigationController.view.sendSubviewToBack(navigationController.navigationBar)
+        
+        let remainingHeight = view.frame.height - (CGFloat(tabBarItems.count) * 44.0) - tableView.contentInset.top - 20
+        
+        // Make sure to resize when rotate and remaining height changes!
+        if remainingHeight != tabBarItems.first?.remainingHeight {
+            
+            tabBarItems.enumerated().forEach { (index, tabItem) in
+                tabItem.remainingHeight = remainingHeight
+            }
+            
+            if let selectedIndex = selectedTabIndex, tabBarItems[selectedIndex].expanded {
+                tableView.reloadRows(at: [IndexPath(row: selectedIndex, section: 0)], with: .automatic)
+            }
+        }
+        
+        if tableView.contentInset == .zero {
+            
+            tableView.clipsToBounds = false
+            tableView.contentInset = .zero
+        }
+    }
+    
+    //MARK: -
+    //MARK: - Drawing
+    
+    private func redraw() {
+        
+        let remainingHeight = view.frame.height - (CGFloat(tabBarItems.count) * 44.0) - tableView.contentInset.top - 20
+        
+        tabBarItems.enumerated().forEach { (index, tabItem) in
+            tabItem.expanded = index == selectedTabIndex
+            tabItem.remainingHeight = remainingHeight
+            tabItem.isFirstItem = index == 0
+        }
+        
+        let tabSection = TableSection(rows: tabBarItems, header: nil, footer: nil) { (row, selected, indexPath, tableView) -> (Void) in
+            
+            guard let tabItem = row as? AccordionTabBarItem else { return }
+            
+            // Set selected tab and then show placeholder view controller
+            self.selectedTabIndex = indexPath.row
+            self.showPlaceholderViewController()
+            
+            // Index paths to redraw
+            var redrawIndexPaths: [IndexPath] = [indexPath]
+            
+            var previousViewController: UIViewController?
+            
+            // Order of this line and line where we toggle the selected items expanded is important as we want to close the selected
+            // row before toggling the one which was just selected!
+            if let selectedIndex = self.tabBarItems.enumerated().first(where: { $0.1.expanded }), indexPath.row != selectedIndex.offset {
+                
+                previousViewController = selectedIndex.element.viewController
+                redrawIndexPaths.append(IndexPath(row: selectedIndex.offset, section: 0))
+                selectedIndex.element.expanded = false
+            }
+            
+            // If was previously expanded it's view controller will be hidden
+            if tabItem.expanded {
+                previousViewController = tabItem.viewController
+            }
+            
+            tabItem.expanded = !tabItem.expanded
+            
+            // If we've expanded a view controller
+            if tabItem.expanded {
+                tabItem.viewController.willMove(toParent: self)
+            } else {
+                self.selectedTabIndex = nil
+            }
+            
+            // View will move to logic!
+            previousViewController?.willMove(toParent: nil)
+            tableView.reloadRows(at: redrawIndexPaths, with: .automatic)
+            
+            previousViewController?.removeFromParent()
+            previousViewController?.didMove(toParent: nil)
+            
+            if tabItem.expanded {
+                
+                // Make sure to add child view controller!
+                self.addChild(tabItem.viewController)
+                tabItem.viewController.didMove(toParent: self)
+                
+                // Must do this otherwise pushing into details view doesn't work on tab > 0
+                if let listPage = tabItem.viewController as? ListPage {
+                    listPage.data = listPage.data
+                }
+            }
+        }
+        
+        data = [tabSection]
+    }
+    
+    //MARK: -
+    //MARK: - Helpers
+    
+    private func showPlaceholderViewController() {
+        
+        guard UI_USER_INTERFACE_IDIOM() == .pad, let selectedTabIndex = selectedTabIndex, selectedTabIndex < placeholders.count else { return }
+        
+        var splitViewController: SplitViewController?
+        
+        if let applicationWindow = UIApplication.shared.keyWindow {
+            splitViewController = applicationWindow.rootViewController as? SplitViewController
+            // This is gross.. because window is `UIWindow??` on app delegate for some reason...
+        } else if let delegateWindow = UIApplication.shared.delegate?.window ?? nil {
+            splitViewController = delegateWindow.rootViewController as? SplitViewController
+        }
+        
+        guard let _splitViewController = splitViewController else {
+            return
+        }
+        
+        let placeholder = placeholders[selectedTabIndex]
+        
+        let placeholderVC = PlaceholderViewController(placeholder: placeholder)
+        
+        _splitViewController.detailViewController = UINavigationController(rootViewController: placeholderVC)
+    }
+    
+    //MARK: -
+    //MARK: - UITableViewDataSource
+    
+    override open func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        
+        guard indexPath.row < tabBarItems.count else {
+            return super.tableView(tableView, heightForRowAt: indexPath)
+        }
+        
+        let tabItem = tabBarItems[indexPath.row]
+        
+        return tabItem.height(constrainedTo: .zero, in: tableView) ?? super.tableView(tableView, heightForRowAt: indexPath)
+    }
+    
+    override open func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        
+        guard indexPath.row < tabBarItems.count else {
+            return super.tableView(tableView, estimatedHeightForRowAt: indexPath)
+        }
+        
+        let tabItem = tabBarItems[indexPath.row]
+        
+        return tabItem.height(constrainedTo: .zero, in: tableView) ?? super.tableView(tableView, estimatedHeightForRowAt: indexPath)
+    }
+    
+    // We have to override this to fix it being set to false when iPad is in portrait
+    open override var extendedLayoutIncludesOpaqueBars: Bool {
+        get {
+            return true
+        }
+        set {}
+    }
 }

--- a/ThunderCloud/AccordionTabBarViewController.swift
+++ b/ThunderCloud/AccordionTabBarViewController.swift
@@ -207,10 +207,9 @@ open class AccordionTabBarViewController: TableViewController, StormObjectProtoc
                     return
                 }
                 
-                navTabController.tabBarItem.image = StormGenerator.image(fromJSON: tabBarItemDict["image"])
-                if let imageDict = tabBarItemDict["image"] as? [AnyHashable : Any], let accessibilityLabelDict = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
-                    navTabController.tabBarItem.accessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
-                }
+                let tabImage = StormGenerator.image(fromJSON: tabBarItemDict["image"])
+                navTabController.tabBarItem.image = tabImage?.image
+                navTabController.tabBarItem.accessibilityLabel = tabImage?.accessibilityLabel
                 
                 if let title = tabBarItemDict["title"] as? [AnyHashable : Any] {
                     navTabController.title = StormLanguageController.shared.string(for: title)
@@ -235,10 +234,9 @@ open class AccordionTabBarViewController: TableViewController, StormObjectProtoc
                     viewController.tabBarItem.title = StormLanguageController.shared.string(for: title)
                 }
                 
-                viewController.tabBarItem.image = StormGenerator.image(fromJSON: tabBarItemDict["image"])
-                if let imageDict = tabBarItemDict["image"] as? [AnyHashable : Any], let accessibilityLabelDict = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
-                    viewController.tabBarItem.accessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
-                }
+                let tabImage = StormGenerator.image(fromJSON: tabBarItemDict["image"])
+                viewController.tabBarItem.image = tabImage?.image
+                viewController.tabBarItem.accessibilityLabel = tabImage?.accessibilityLabel
                 
                 viewControllers.append(viewController)
                 viewControllersShouldDisplayNavigationBar.append(false)

--- a/ThunderCloud/AnimatedImageListItem.swift
+++ b/ThunderCloud/AnimatedImageListItem.swift
@@ -60,5 +60,6 @@ open class AnimatedImageListItem: ImageListItem {
 		
 		animatedCell.frames = frames
 		animatedCell.resetAnimations()
+        animatedCell.imageView?.accessibilityLabel = imageAccessibilityLabel
 	}
 }

--- a/ThunderCloud/AnimatedImageListItem.swift
+++ b/ThunderCloud/AnimatedImageListItem.swift
@@ -20,10 +20,14 @@ open class AnimatedImageListItem: ImageListItem {
 	
 	/// An array of delays to apply between each consecutive frame
 	public var delays: [TimeInterval] = []
-	
+    	
 	required public init(dictionary: [AnyHashable : Any]) {
 		
 		super.init(dictionary: dictionary)
+        
+        if let accessibilityLabelDict = dictionary["accessibilityLabel"] as? [AnyHashable : Any] {
+            imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
+        }
 		
 		guard let animatedImageDictionaries = dictionary["images"] as? [[AnyHashable : Any]] else { return }
 		

--- a/ThunderCloud/AnimatedImageListItem.swift
+++ b/ThunderCloud/AnimatedImageListItem.swift
@@ -12,54 +12,54 @@ import ThunderTable
 /// Subclass of `ImageListItem` which displays an array of animated images at the aspect ratio of the first image in the set, delaying between each one by a defined amount of time
 @available(*, deprecated, message: "Please use `AnimationListItem` instead")
 open class AnimatedImageListItem: ImageListItem {
-	
-	public var frames: [(image: UIImage, delay: TimeInterval)] = []
-	
-	/// The array of images to animate
-	public var images: [UIImage] = []
-	
-	/// An array of delays to apply between each consecutive frame
-	public var delays: [TimeInterval] = []
-    	
-	required public init(dictionary: [AnyHashable : Any]) {
-		
-		super.init(dictionary: dictionary)
+    
+    public var frames: [(image: UIImage, delay: TimeInterval)] = []
+    
+    /// The array of images to animate
+    public var images: [UIImage] = []
+    
+    /// An array of delays to apply between each consecutive frame
+    public var delays: [TimeInterval] = []
+    
+    required public init(dictionary: [AnyHashable : Any]) {
+        
+        super.init(dictionary: dictionary)
         
         if let accessibilityLabelDict = dictionary["accessibilityLabel"] as? [AnyHashable : Any] {
             imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
         }
-		
-		guard let animatedImageDictionaries = dictionary["images"] as? [[AnyHashable : Any]] else { return }
-		
-		frames = animatedImageDictionaries.compactMap({ (animatedImageDict) -> (image: UIImage, delay: TimeInterval)? in
-			
-			guard let image = StormGenerator.image(fromJSON: animatedImageDict) else { return nil }
-			guard let delay = animatedImageDict["delay"] as? TimeInterval else { return nil }
-			
-			return (image: image, delay: delay)
-		})
-	}
-	
-	override open var image: UIImage? {
-		get {
-			return frames.first?.image
-		}
-		set {
-			super.image = newValue
-		}
-	}
-	
-	override open var cellClass: UITableViewCell.Type? {
-		return AnimatedImageListCell.self
-	}
-	
-	override open func configure(cell: UITableViewCell, at indexPath: IndexPath, in tableViewController: TableViewController) {
-		
-		super.configure(cell: cell, at: indexPath, in: tableViewController)
-		guard let animatedCell = cell as? AnimatedImageListCell else { return }
-		
-		animatedCell.frames = frames
-		animatedCell.resetAnimations()
+        
+        guard let animatedImageDictionaries = dictionary["images"] as? [[AnyHashable : Any]] else { return }
+        
+        frames = animatedImageDictionaries.compactMap({ (animatedImageDict) -> (image: UIImage, delay: TimeInterval)? in
+            
+            guard let image = StormGenerator.image(fromJSON: animatedImageDict) else { return nil }
+            guard let delay = animatedImageDict["delay"] as? TimeInterval else { return nil }
+            
+            return (image: image, delay: delay)
+        })
+    }
+    
+    override open var image: UIImage? {
+        get {
+            return frames.first?.image
+        }
+        set {
+            super.image = newValue
+        }
+    }
+    
+    override open var cellClass: UITableViewCell.Type? {
+        return AnimatedImageListCell.self
+    }
+    
+    override open func configure(cell: UITableViewCell, at indexPath: IndexPath, in tableViewController: TableViewController) {
+        
+        super.configure(cell: cell, at: indexPath, in: tableViewController)
+        guard let animatedCell = cell as? AnimatedImageListCell else { return }
+        
+        animatedCell.frames = frames
+        animatedCell.resetAnimations()
         animatedCell.imageView?.accessibilityLabel = imageAccessibilityLabel
-	}
+    }
 }

--- a/ThunderCloud/AnimatedImageListItem.swift
+++ b/ThunderCloud/AnimatedImageListItem.swift
@@ -21,11 +21,14 @@ open class AnimatedImageListItem: ImageListItem {
     /// An array of delays to apply between each consecutive frame
     public var delays: [TimeInterval] = []
     
+    /// The image accessibility label for the animated image list item
+    public var imageAccessibilityLabel: String?
+    
     required public init(dictionary: [AnyHashable : Any]) {
         
         super.init(dictionary: dictionary)
         
-        if let accessibilityLabelDict = dictionary["accessibilityLabel"] as? [AnyHashable : Any] {
+        if let accessibilityLabelDict = dictionary["accessibilityLabel"] as? [AnyHashable : Any], let image = stormImage {
             imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
         }
         
@@ -36,7 +39,7 @@ open class AnimatedImageListItem: ImageListItem {
             guard let image = StormGenerator.image(fromJSON: animatedImageDict) else { return nil }
             guard let delay = animatedImageDict["delay"] as? TimeInterval else { return nil }
             
-            return (image: image, delay: delay)
+            return (image: image.image, delay: delay)
         })
     }
     
@@ -60,6 +63,6 @@ open class AnimatedImageListItem: ImageListItem {
         
         animatedCell.frames = frames
         animatedCell.resetAnimations()
-        animatedCell.imageView?.accessibilityLabel = imageAccessibilityLabel
+        animatedCell.cellImageView?.accessibilityLabel = imageAccessibilityLabel
     }
 }

--- a/ThunderCloud/Animation.swift
+++ b/ThunderCloud/Animation.swift
@@ -21,6 +21,9 @@ public struct Animation {
 		
 		/// The image to display for this frame
 		public let image: UIImage?
+        
+        /// The accessibility label to display for this frame
+        public let imageAccessibilityLabel: String?
 		
 		/// Creates a frame from a storm dictionary
 		///
@@ -29,6 +32,11 @@ public struct Animation {
 			
 			delay = dictionary["delay"] as? TimeInterval ?? 1
 			image = StormGenerator.image(fromJSON: dictionary["image"])
+            if let imageDict = dictionary["image"] as? [AnyHashable : Any], let accessibilityLabelDict = imageDict["imageAccessibilityLabel"] as? [AnyHashable : Any] {
+                imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
+            } else {
+                imageAccessibilityLabel = nil
+            }
 		}
 	}
 	

--- a/ThunderCloud/Animation.swift
+++ b/ThunderCloud/Animation.swift
@@ -12,50 +12,50 @@ import Foundation
 ///
 /// Contains info about the frames and whether or not the animagion is looped
 public struct Animation {
-	
-	/// Single frame of an animation
-	public struct Frame {
-		
-		/// Delay in seconds before the next frame
-		public let delay: TimeInterval
-		
-		/// The image to display for this frame
-		public let image: UIImage?
+    
+    /// Single frame of an animation
+    public struct Frame {
+        
+        /// Delay in seconds before the next frame
+        public let delay: TimeInterval
+        
+        /// The image to display for this frame
+        public let image: UIImage?
         
         /// The accessibility label to display for this frame
         public let imageAccessibilityLabel: String?
-		
-		/// Creates a frame from a storm dictionary
-		///
-		/// - Parameter dictionary: Dictionary representation of the frame
-		init(dictionary: [AnyHashable : Any]) {
-			
-			delay = dictionary["delay"] as? TimeInterval ?? 1
-			image = StormGenerator.image(fromJSON: dictionary["image"])
+        
+        /// Creates a frame from a storm dictionary
+        ///
+        /// - Parameter dictionary: Dictionary representation of the frame
+        init(dictionary: [AnyHashable : Any]) {
+            
+            delay = dictionary["delay"] as? TimeInterval ?? 1
+            image = StormGenerator.image(fromJSON: dictionary["image"])
             if let imageDict = dictionary["image"] as? [AnyHashable : Any], let accessibilityLabelDict = imageDict["imageAccessibilityLabel"] as? [AnyHashable : Any] {
                 imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
             } else {
                 imageAccessibilityLabel = nil
             }
-		}
-	}
-	
-	/// The array of frames that compose the animation
-	public let frames: [Animation.Frame]
-	
-	/// Whether the animation should loop
-	public let looped: Bool
-	
-	/// Creates a new instance using a storm dictionary object
-	///
-	/// - Parameter dictionary: A storm dictionary with animation information
-	public init?(dictionary: [AnyHashable : Any]) {
-		
-		guard let framesArray = (dictionary["frames"] as? [[AnyHashable : Any]]) else { return nil }
-		
-		frames = framesArray.map({
-			return Animation.Frame(dictionary: $0)
-		})
-		looped = dictionary["looped"] as? Bool ?? false
-	}
+        }
+    }
+    
+    /// The array of frames that compose the animation
+    public let frames: [Animation.Frame]
+    
+    /// Whether the animation should loop
+    public let looped: Bool
+    
+    /// Creates a new instance using a storm dictionary object
+    ///
+    /// - Parameter dictionary: A storm dictionary with animation information
+    public init?(dictionary: [AnyHashable : Any]) {
+        
+        guard let framesArray = (dictionary["frames"] as? [[AnyHashable : Any]]) else { return nil }
+        
+        frames = framesArray.map({
+            return Animation.Frame(dictionary: $0)
+        })
+        looped = dictionary["looped"] as? Bool ?? false
+    }
 }

--- a/ThunderCloud/Animation.swift
+++ b/ThunderCloud/Animation.swift
@@ -20,10 +20,7 @@ public struct Animation {
         public let delay: TimeInterval
         
         /// The image to display for this frame
-        public let image: UIImage?
-        
-        /// The accessibility label to display for this frame
-        public let imageAccessibilityLabel: String?
+        public let image: StormImage?
         
         /// Creates a frame from a storm dictionary
         ///
@@ -32,11 +29,6 @@ public struct Animation {
             
             delay = dictionary["delay"] as? TimeInterval ?? 1
             image = StormGenerator.image(fromJSON: dictionary["image"])
-            if let imageDict = dictionary["image"] as? [AnyHashable : Any], let accessibilityLabelDict = imageDict["imageAccessibilityLabel"] as? [AnyHashable : Any] {
-                imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
-            } else {
-                imageAccessibilityLabel = nil
-            }
         }
     }
     

--- a/ThunderCloud/AnimationListItemCell.swift
+++ b/ThunderCloud/AnimationListItemCell.swift
@@ -32,7 +32,7 @@ open class AnimationListItemCell: TableImageViewCell {
 		guard let animation = animation, currentIndex < animation.frames.count else { return }
 		
 		let currentFrame = animation.frames[currentIndex]
-		cellImageView?.image = currentFrame.image
+		cellImageView?.image = currentFrame.image?.image
 		
 		if animation.frames.count > currentIndex {
 			

--- a/ThunderCloud/AppCollectionCell.swift
+++ b/ThunderCloud/AppCollectionCell.swift
@@ -61,6 +61,7 @@ extension AppCollectionCell {
         guard let apps = apps, let appCell = cell as? AppScrollerItemViewCell else { return cell }
         
         let app = apps[indexPath.row]
+        appCell.appIconView.accessibilityLabel = app.iconAccessibilityLabel
         appCell.appIconView.image = app.appIcon
         appCell.nameLabel.text = app.appName
         appCell.priceLabel.text = app.appPrice

--- a/ThunderCloud/AppCollectionItem.swift
+++ b/ThunderCloud/AppCollectionItem.swift
@@ -10,54 +10,54 @@ import Foundation
 
 /// A model representation of an app to be shown in a `TSCAppScrollerItemViewCell`
 open class AppCollectionItem: StormObjectProtocol {
-	
-	/// The app's icon
-	public let appIcon: UIImage?
+    
+    /// The app's icon
+    public let appIcon: UIImage?
     
     /// The app icon's accessibility label
     public let iconAccessibilityLabel: String?
-	
-	/// The app's name
-	public let appName: String?
-	
-	/// The app's price
-	public let appPrice: String?
-	
-	/// The app identity for the app, contains information on the URL schemes, app name, iTunes id e.t.c.
-	public let app: AppIdentity?
-	
-	/// Initialises a new instance from a CMS representation of an app
-	///
-	/// - Parameter dictionary: Dictionary to use to initialise and populate the app
-	public required init(dictionary: [AnyHashable : Any]) {
-		
-		appIcon = StormGenerator.image(fromJSON: dictionary["icon"])
+    
+    /// The app's name
+    public let appName: String?
+    
+    /// The app's price
+    public let appPrice: String?
+    
+    /// The app identity for the app, contains information on the URL schemes, app name, iTunes id e.t.c.
+    public let app: AppIdentity?
+    
+    /// Initialises a new instance from a CMS representation of an app
+    ///
+    /// - Parameter dictionary: Dictionary to use to initialise and populate the app
+    public required init(dictionary: [AnyHashable : Any]) {
+        
+        appIcon = StormGenerator.image(fromJSON: dictionary["icon"])
         
         if let imageDict = dictionary["icon"] as? [AnyHashable : Any], let accessibilityLabelDictionary = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
             iconAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDictionary)
         } else {
             iconAccessibilityLabel = nil
         }
-		
-		var appIdentifier: AppIdentity?
-		
-		if let identifier = dictionary["identifier"] as? String {
-			appIdentifier = AppLinkController().apps.first(where: {$0.identifier == identifier})
-			app = appIdentifier
-		} else {
-			app = nil
-		}
-		
-		if let nameKey = dictionary["name"] as? String {
-			appName = StormLanguageController.shared.string(forKey: nameKey) ?? appIdentifier?.name
-		} else {
-			appName = app?.name
-		}
-		
-		if let priceDictionary = dictionary["overlay"] as? [AnyHashable : Any] {
-			appPrice = StormLanguageController.shared.string(for: priceDictionary)
-		} else {
-			appPrice = nil
-		}
-	}
+        
+        var appIdentifier: AppIdentity?
+        
+        if let identifier = dictionary["identifier"] as? String {
+            appIdentifier = AppLinkController().apps.first(where: {$0.identifier == identifier})
+            app = appIdentifier
+        } else {
+            app = nil
+        }
+        
+        if let nameKey = dictionary["name"] as? String {
+            appName = StormLanguageController.shared.string(forKey: nameKey) ?? appIdentifier?.name
+        } else {
+            appName = app?.name
+        }
+        
+        if let priceDictionary = dictionary["overlay"] as? [AnyHashable : Any] {
+            appPrice = StormLanguageController.shared.string(for: priceDictionary)
+        } else {
+            appPrice = nil
+        }
+    }
 }

--- a/ThunderCloud/AppCollectionItem.swift
+++ b/ThunderCloud/AppCollectionItem.swift
@@ -13,6 +13,9 @@ open class AppCollectionItem: StormObjectProtocol {
 	
 	/// The app's icon
 	public let appIcon: UIImage?
+    
+    /// The app icon's accessibility label
+    public let iconAccessibilityLabel: String?
 	
 	/// The app's name
 	public let appName: String?
@@ -29,6 +32,10 @@ open class AppCollectionItem: StormObjectProtocol {
 	public required init(dictionary: [AnyHashable : Any]) {
 		
 		appIcon = StormGenerator.image(fromJSON: dictionary["icon"])
+        
+        if let imageDict = dictionary["icon"] as? [AnyHashable : Any], let accessibilityLabelDictionary = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
+            iconAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDictionary)
+        }
 		
 		var appIdentifier: AppIdentity?
 		

--- a/ThunderCloud/AppCollectionItem.swift
+++ b/ThunderCloud/AppCollectionItem.swift
@@ -31,13 +31,9 @@ open class AppCollectionItem: StormObjectProtocol {
     /// - Parameter dictionary: Dictionary to use to initialise and populate the app
     public required init(dictionary: [AnyHashable : Any]) {
         
-        appIcon = StormGenerator.image(fromJSON: dictionary["icon"])
-        
-        if let imageDict = dictionary["icon"] as? [AnyHashable : Any], let accessibilityLabelDictionary = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
-            iconAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDictionary)
-        } else {
-            iconAccessibilityLabel = nil
-        }
+        let icon = StormGenerator.image(fromJSON: dictionary["icon"])
+        appIcon = icon?.image
+        iconAccessibilityLabel = icon?.accessibilityLabel
         
         var appIdentifier: AppIdentity?
         

--- a/ThunderCloud/AppCollectionItem.swift
+++ b/ThunderCloud/AppCollectionItem.swift
@@ -35,6 +35,8 @@ open class AppCollectionItem: StormObjectProtocol {
         
         if let imageDict = dictionary["icon"] as? [AnyHashable : Any], let accessibilityLabelDictionary = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
             iconAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDictionary)
+        } else {
+            iconAccessibilityLabel = nil
         }
 		
 		var appIdentifier: AppIdentity?

--- a/ThunderCloud/AreaSelectionQuestion.swift
+++ b/ThunderCloud/AreaSelectionQuestion.swift
@@ -10,153 +10,153 @@ import UIKit
 
 /// A cartesian coordinate in the x,y,z plans
 public struct Coordinate {
-	
-	/// The x coordinate
-	public let x: Double
-	
-	/// The y coordinate
-	public let y: Double
-	
-	/// The z coordinate
-	public let z: Double
-	
-	/// A 2D representation of the coordinate in the x-y plane
-	public var point: CGPoint {
-		return CGPoint(x: x, y: y)
-	}
-	
-	/// Initialises a new coordinate from a dictionary representation
-	///
-	/// - Parameter dictionary: The dictionary representation of the coordinate
-	init(dictionary: [AnyHashable : Any]) {
-		
-		if let x = dictionary["x"] as? Double {
-			self.x = x
-		} else if let x = dictionary["x"] as? Int {
-			self.x = Double(x)
-		} else {
-			x = 0
-		}
-		
-		if let y = dictionary["y"] as? Double {
-			self.y = y
-		} else if let y = dictionary["y"] as? Int {
-			self.y = Double(y)
-		} else {
-			y = 0
-		}
-		
-		if let z = dictionary["z"] as? Double {
-			self.z = z
-		} else if let z = dictionary["z"] as? Int {
-			self.z = Double(z)
-		} else {
-			z = 0
-		}
-	}
-	
-	/// Initialises a coordinage from a 2D CGPoint
-	///
-	/// - Parameter point: the point to construct the coordinate from
-	public init(point: CGPoint) {
-		
-		x = Double(point.x)
-		y = Double(point.y)
-		z = 0
-	}
+    
+    /// The x coordinate
+    public let x: Double
+    
+    /// The y coordinate
+    public let y: Double
+    
+    /// The z coordinate
+    public let z: Double
+    
+    /// A 2D representation of the coordinate in the x-y plane
+    public var point: CGPoint {
+        return CGPoint(x: x, y: y)
+    }
+    
+    /// Initialises a new coordinate from a dictionary representation
+    ///
+    /// - Parameter dictionary: The dictionary representation of the coordinate
+    init(dictionary: [AnyHashable : Any]) {
+        
+        if let x = dictionary["x"] as? Double {
+            self.x = x
+        } else if let x = dictionary["x"] as? Int {
+            self.x = Double(x)
+        } else {
+            x = 0
+        }
+        
+        if let y = dictionary["y"] as? Double {
+            self.y = y
+        } else if let y = dictionary["y"] as? Int {
+            self.y = Double(y)
+        } else {
+            y = 0
+        }
+        
+        if let z = dictionary["z"] as? Double {
+            self.z = z
+        } else if let z = dictionary["z"] as? Int {
+            self.z = Double(z)
+        } else {
+            z = 0
+        }
+    }
+    
+    /// Initialises a coordinage from a 2D CGPoint
+    ///
+    /// - Parameter point: the point to construct the coordinate from
+    public init(point: CGPoint) {
+        
+        x = Double(point.x)
+        y = Double(point.y)
+        z = 0
+    }
 }
 
 public func ==(lhs: Coordinate?, rhs: Coordinate?) -> Bool {
-	guard let _lhs = lhs, let _rhs = rhs else {
-		// Have to use this syntax otherwise we get a recurssion loop
-		// If one of them is non-nil then they're not equal
-		if let _ = lhs {
-			return false
-		}
-		if let _ = rhs {
-			return false
-		}
-		return true
-	}
-	return _lhs.x == _rhs.x && _lhs.y == _rhs.y && _lhs.z == _rhs.z
+    guard let _lhs = lhs, let _rhs = rhs else {
+        // Have to use this syntax otherwise we get a recurssion loop
+        // If one of them is non-nil then they're not equal
+        if let _ = lhs {
+            return false
+        }
+        if let _ = rhs {
+            return false
+        }
+        return true
+    }
+    return _lhs.x == _rhs.x && _lhs.y == _rhs.y && _lhs.z == _rhs.z
 }
 
 /// A zone to be used with AreaSelectionQuestion represented by a collection of points
 public struct Zone {
-	
-	/// The bounding coordinates for the zone
-	public let coordinates: [Coordinate]
-	
-	init?(dictionary: [AnyHashable : Any]) {
-		
-		guard let coordinates = dictionary["coordinates"] as? [[AnyHashable : Any]] else { return nil }
-		self.coordinates = coordinates.map({ (coordinateDict) -> Coordinate in
-			return Coordinate(dictionary: coordinateDict)
-		})
-	}
-	
-	/// Returns whether the zone contains a point
-	///
-	/// - Parameter point: The point to test against
-	/// - Returns: A bool as to whether the point lies within the zone
-	public func contains(point: CGPoint) -> Bool {
-		
-		guard let firstCoordinate = coordinates.first else {
-			return false
-		}
-		
-		guard coordinates.count > 1 else {
-			return Coordinate(point: point) == coordinates.first
-		}
-		
-		let path = UIBezierPath()
-		
-		path.move(to: firstCoordinate.point)
-		for index in 1...coordinates.count-1 {
-			path.addLine(to: coordinates[index].point)
-		}
-		path.close()
-		
-		return path.contains(point)
-	}
+    
+    /// The bounding coordinates for the zone
+    public let coordinates: [Coordinate]
+    
+    init?(dictionary: [AnyHashable : Any]) {
+        
+        guard let coordinates = dictionary["coordinates"] as? [[AnyHashable : Any]] else { return nil }
+        self.coordinates = coordinates.map({ (coordinateDict) -> Coordinate in
+            return Coordinate(dictionary: coordinateDict)
+        })
+    }
+    
+    /// Returns whether the zone contains a point
+    ///
+    /// - Parameter point: The point to test against
+    /// - Returns: A bool as to whether the point lies within the zone
+    public func contains(point: CGPoint) -> Bool {
+        
+        guard let firstCoordinate = coordinates.first else {
+            return false
+        }
+        
+        guard coordinates.count > 1 else {
+            return Coordinate(point: point) == coordinates.first
+        }
+        
+        let path = UIBezierPath()
+        
+        path.move(to: firstCoordinate.point)
+        for index in 1...coordinates.count-1 {
+            path.addLine(to: coordinates[index].point)
+        }
+        path.close()
+        
+        return path.contains(point)
+    }
 }
 
 /// The user is presented with an image and must click on the correct location in the image
 public class AreaSelectionQuestion: QuizQuestion {
-	
-	/// The image that the user should select an area on (Cannot be called `image` due to Row conformance)
+    
+    /// The image that the user should select an area on (Cannot be called `image` due to Row conformance)
     public let selectionImage: UIImage
-	
-	/// A zone representing an area in which the user can tap and be marked as correct
+    
+    /// A zone representing an area in which the user can tap and be marked as correct
     public let correctAnswer: Zone
     
     /// The accessibility label for the image that the user is selecting an area on
     public let imageAccessibilityLabel: String?
-	
-	public var answer: CGPoint? {
-		didSet {
-			postNotification(notification: .answerChanged, object: self)
-		}
-	}
-	
+    
+    public var answer: CGPoint? {
+        didSet {
+            postNotification(notification: .answerChanged, object: self)
+        }
+    }
+    
     override public var isCorrect: Bool {
-		get {
-			guard let answer = answer else { return false }
-			return correctAnswer.contains(point: answer)
-		}
-		set {}
-	}
-	
+        get {
+            guard let answer = answer else { return false }
+            return correctAnswer.contains(point: answer)
+        }
+        set {}
+    }
+    
     override public var answered: Bool {
-		get {
-			return answer != nil
-		}
-		set {}
-	}
-	
-	override init?(dictionary: [AnyHashable : Any]) {
-		
-		guard let imageObject = dictionary["image"] else { return nil }
+        get {
+            return answer != nil
+        }
+        set {}
+    }
+    
+    override init?(dictionary: [AnyHashable : Any]) {
+        
+        guard let imageObject = dictionary["image"] else { return nil }
         
         if let imageDict = imageObject as? [AnyHashable : Any], let accessibilityLabelDictionary = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
             imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDictionary)
@@ -164,27 +164,27 @@ public class AreaSelectionQuestion: QuizQuestion {
             imageAccessibilityLabel = nil
         }
         
-		guard let image = StormGenerator.image(fromJSON: imageObject) else { return nil }
-		
-		selectionImage = image
-		
-		guard let zoneObjects = dictionary["answer"] as? [[AnyHashable : Any]], let firstZone = zoneObjects.first else { return nil }
-		guard let answer = Zone(dictionary: firstZone) else { return nil }
-		
-		correctAnswer = answer
-		
-		super.init(dictionary: dictionary)
-	}
-	
+        guard let image = StormGenerator.image(fromJSON: imageObject) else { return nil }
+        
+        selectionImage = image
+        
+        guard let zoneObjects = dictionary["answer"] as? [[AnyHashable : Any]], let firstZone = zoneObjects.first else { return nil }
+        guard let answer = Zone(dictionary: firstZone) else { return nil }
+        
+        correctAnswer = answer
+        
+        super.init(dictionary: dictionary)
+    }
+    
     override public func reset() {
-		answer = nil
-	}
-	
-	override func answerCorrectly() {
-		answer = correctAnswer.coordinates.first!.point
-	}
-	
-	override func answerRandomly() {
-		answer = CGPoint(x: CGFloat(Float(arc4random()) / Float(UINT32_MAX)), y: CGFloat(Float(arc4random()) / Float(UINT32_MAX)))
-	}
+        answer = nil
+    }
+    
+    override func answerCorrectly() {
+        answer = correctAnswer.coordinates.first!.point
+    }
+    
+    override func answerRandomly() {
+        answer = CGPoint(x: CGFloat(Float(arc4random()) / Float(UINT32_MAX)), y: CGFloat(Float(arc4random()) / Float(UINT32_MAX)))
+    }
 }

--- a/ThunderCloud/AreaSelectionQuestion.swift
+++ b/ThunderCloud/AreaSelectionQuestion.swift
@@ -129,6 +129,9 @@ public class AreaSelectionQuestion: QuizQuestion {
 	
 	/// A zone representing an area in which the user can tap and be marked as correct
     public let correctAnswer: Zone
+    
+    /// The accessibility label for the image that the user is selecting an area on
+    public let imageAccessibilityLabel: String?
 	
 	public var answer: CGPoint? {
 		didSet {
@@ -154,6 +157,13 @@ public class AreaSelectionQuestion: QuizQuestion {
 	override init?(dictionary: [AnyHashable : Any]) {
 		
 		guard let imageObject = dictionary["image"] else { return nil }
+        
+        if let imageDict = imageObject as? [AnyHashable : Any], let accessibilityLabelDictionary = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
+            imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDictionary)
+        } else {
+            imageAccessibilityLabel = nil
+        }
+        
 		guard let image = StormGenerator.image(fromJSON: imageObject) else { return nil }
 		
 		selectionImage = image

--- a/ThunderCloud/AreaSelectionQuestion.swift
+++ b/ThunderCloud/AreaSelectionQuestion.swift
@@ -125,13 +125,10 @@ public struct Zone {
 public class AreaSelectionQuestion: QuizQuestion {
     
     /// The image that the user should select an area on (Cannot be called `image` due to Row conformance)
-    public let selectionImage: UIImage
+    public let selectionImage: StormImage
     
     /// A zone representing an area in which the user can tap and be marked as correct
     public let correctAnswer: Zone
-    
-    /// The accessibility label for the image that the user is selecting an area on
-    public let imageAccessibilityLabel: String?
     
     public var answer: CGPoint? {
         didSet {
@@ -157,12 +154,6 @@ public class AreaSelectionQuestion: QuizQuestion {
     override init?(dictionary: [AnyHashable : Any]) {
         
         guard let imageObject = dictionary["image"] else { return nil }
-        
-        if let imageDict = imageObject as? [AnyHashable : Any], let accessibilityLabelDictionary = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
-            imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDictionary)
-        } else {
-            imageAccessibilityLabel = nil
-        }
         
         guard let image = StormGenerator.image(fromJSON: imageObject) else { return nil }
         

--- a/ThunderCloud/Badge.swift
+++ b/ThunderCloud/Badge.swift
@@ -33,6 +33,12 @@ open class Badge: NSObject, StormObjectProtocol {
     open lazy var icon: UIImage? = { [unowned self] in
 		return StormGenerator.image(fromJSON: iconObject)
 	}()
+    
+    /// The accessibility label of the badge icon
+    public var iconAccessibilityLabel: String? {
+        guard let iconDict = iconObject as? [AnyHashable : Any], let accessibilityLabelDict = iconDict["accessibilityLabel"] as? [AnyHashable : Any] else { return nil }
+        return StormLanguageController.shared.string(for: accessibilityLabelDict)
+    }
 	
 	required public init(dictionary: [AnyHashable : Any]) {
 		

--- a/ThunderCloud/Badge.swift
+++ b/ThunderCloud/Badge.swift
@@ -10,72 +10,72 @@ import UIKit
 
 /// `Badge` is a model representation of a storm badge object
 open class Badge: NSObject, StormObjectProtocol {
-	
-	/// A string of text that is displayed when the badge is unlocked
+    
+    /// A string of text that is displayed when the badge is unlocked
     public let completionText: String?
-	
-	/// A string of text which informs the user how to unlock the badge
+    
+    /// A string of text which informs the user how to unlock the badge
     public let howToEarnText: String?
-	
-	/// The text that is used when the user shares the badge
+    
+    /// The text that is used when the user shares the badge
     public let shareMessage: String?
-	
-	/// The title of the badge
+    
+    /// The title of the badge
     public let title: String?
-	
-	/// The unique identifier for the badge
+    
+    /// The unique identifier for the badge
     public let id: String?
-	
-	/// A `Dictionary` representation of the badge's icon, this can be converted to a `TSCImage` to return the `UIImage` representation of the icon
-	private var iconObject: Any?
-	
-	/// The badge's icon, to be displayed in any badge scrollers e.t.c.
+    
+    /// A `Dictionary` representation of the badge's icon, this can be converted to a `TSCImage` to return the `UIImage` representation of the icon
+    private var iconObject: Any?
+    
+    /// The badge's icon, to be displayed in any badge scrollers e.t.c.
     open lazy var icon: UIImage? = { [unowned self] in
-		return StormGenerator.image(fromJSON: iconObject)
-	}()
+        return StormGenerator.image(fromJSON: iconObject)
+        }()
     
     /// The accessibility label of the badge icon
     public var iconAccessibilityLabel: String? {
         guard let iconDict = iconObject as? [AnyHashable : Any], let accessibilityLabelDict = iconDict["accessibilityLabel"] as? [AnyHashable : Any] else { return nil }
         return StormLanguageController.shared.string(for: accessibilityLabelDict)
     }
-	
-	required public init(dictionary: [AnyHashable : Any]) {
-		
-		if let completionTextDictionary = dictionary["completion"] as? [AnyHashable : Any] {
-			completionText = StormLanguageController.shared.string(for: completionTextDictionary)
-		} else {
-			completionText = nil
-		}
-		
-		if let howToEarnTextDictionary = dictionary["how"] as? [AnyHashable : Any] {
-			howToEarnText = StormLanguageController.shared.string(for: howToEarnTextDictionary)
-		} else {
-			howToEarnText = nil
-		}
-		
-		if let shareMessageDictionary = dictionary["shareMessage"] as? [AnyHashable : Any] {
-			shareMessage = StormLanguageController.shared.string(for: shareMessageDictionary)
-		} else {
-			shareMessage = nil
-		}
-		
-		if let titleDictionary = dictionary["title"] as? [AnyHashable : Any] {
-			title = StormLanguageController.shared.string(for: titleDictionary)
-		} else {
-			title = nil
-		}
-		
-		if let intId = dictionary["id"] as? Int {
-			id = "\(intId)"
-		} else if let stringId = dictionary["id"] as? String {
-			id = stringId
-		} else {
-			id = nil
-		}
-		
-		iconObject = dictionary["icon"]
-		
-		super.init()
-	}
+    
+    required public init(dictionary: [AnyHashable : Any]) {
+        
+        if let completionTextDictionary = dictionary["completion"] as? [AnyHashable : Any] {
+            completionText = StormLanguageController.shared.string(for: completionTextDictionary)
+        } else {
+            completionText = nil
+        }
+        
+        if let howToEarnTextDictionary = dictionary["how"] as? [AnyHashable : Any] {
+            howToEarnText = StormLanguageController.shared.string(for: howToEarnTextDictionary)
+        } else {
+            howToEarnText = nil
+        }
+        
+        if let shareMessageDictionary = dictionary["shareMessage"] as? [AnyHashable : Any] {
+            shareMessage = StormLanguageController.shared.string(for: shareMessageDictionary)
+        } else {
+            shareMessage = nil
+        }
+        
+        if let titleDictionary = dictionary["title"] as? [AnyHashable : Any] {
+            title = StormLanguageController.shared.string(for: titleDictionary)
+        } else {
+            title = nil
+        }
+        
+        if let intId = dictionary["id"] as? Int {
+            id = "\(intId)"
+        } else if let stringId = dictionary["id"] as? String {
+            id = stringId
+        } else {
+            id = nil
+        }
+        
+        iconObject = dictionary["icon"]
+        
+        super.init()
+    }
 }

--- a/ThunderCloud/Badge.swift
+++ b/ThunderCloud/Badge.swift
@@ -31,13 +31,12 @@ open class Badge: NSObject, StormObjectProtocol {
     
     /// The badge's icon, to be displayed in any badge scrollers e.t.c.
     open lazy var icon: UIImage? = { [unowned self] in
-        return StormGenerator.image(fromJSON: iconObject)
-        }()
+        return StormGenerator.image(fromJSON: iconObject)?.image
+    }()
     
     /// The accessibility label of the badge icon
     public var iconAccessibilityLabel: String? {
-        guard let iconDict = iconObject as? [AnyHashable : Any], let accessibilityLabelDict = iconDict["accessibilityLabel"] as? [AnyHashable : Any] else { return nil }
-        return StormLanguageController.shared.string(for: accessibilityLabelDict)
+        return StormGenerator.image(fromJSON: iconObject)?.accessibilityLabel
     }
     
     required public init(dictionary: [AnyHashable : Any]) {

--- a/ThunderCloud/BadgeScrollerViewCell.swift
+++ b/ThunderCloud/BadgeScrollerViewCell.swift
@@ -161,6 +161,7 @@ open class BadgeScrollerViewCell: CollectionCell {
         
         if let badgeCell = cell as? TSCBadgeScrollerItemViewCell {
             
+            badgeCell.badgeImageView.accessibilityLabel = badge.iconAccessibilityLabel
             badgeCell.badgeImageView.image = badge.icon
             badgeCell.titleLabel.text = badge.title
             

--- a/ThunderCloud/GridItem.swift
+++ b/ThunderCloud/GridItem.swift
@@ -20,10 +20,7 @@ open class GridItem: CollectionItemDisplayable, StormObjectProtocol {
     public let link: StormLink?
     
     /// The image to be displayed when displaying this item in a `UICollectionView`
-    open var image: UIImage?
-    
-    /// The accessibility label for the image displayed in this grid item
-    open var imageAccessibilityLabel: String?
+    open var image: StormImage?
     
     /// The title to be displayed when displaying this item in a `UICollectionView`
     public let title: String?
@@ -54,10 +51,6 @@ open class GridItem: CollectionItemDisplayable, StormObjectProtocol {
         }
         
         image = StormGenerator.image(fromJSON: dictionary["image"])
-        
-        if let imageDict = dictionary["image"] as? [AnyHashable : Any], let accessibilityLabelDictionary = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
-            imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDictionary)
-        }
     }
     
     // This is empty, but must be left here in order for subclasses to implement the method and it still be called

--- a/ThunderCloud/GridItem.swift
+++ b/ThunderCloud/GridItem.swift
@@ -11,67 +11,67 @@ import ThunderCollection
 
 /// A root class for an item to be displayed in a `grid` or `UICollectionView`
 open class GridItem: CollectionItemDisplayable, StormObjectProtocol {
-	
-	open var cellClass: UICollectionViewCell.Type? {
-		return UICollectionViewCell.self
-	}
-	
-	/// A `StormLink` which determines what the item does when it is selected
+    
+    open var cellClass: UICollectionViewCell.Type? {
+        return UICollectionViewCell.self
+    }
+    
+    /// A `StormLink` which determines what the item does when it is selected
     public let link: StormLink?
-	
-	/// The image to be displayed when displaying this item in a `UICollectionView`
-	open var image: UIImage?
+    
+    /// The image to be displayed when displaying this item in a `UICollectionView`
+    open var image: UIImage?
     
     /// The accessibility label for the image displayed in this grid item
     open var imageAccessibilityLabel: String?
-	
-	/// The title to be displayed when displaying this item in a `UICollectionView`
+    
+    /// The title to be displayed when displaying this item in a `UICollectionView`
     public let title: String?
-	
-	/// The description to be displayed when displaying this item in a `UICollectionView`
+    
+    /// The description to be displayed when displaying this item in a `UICollectionView`
     public let description: String?
-	
-	public required init?(dictionary: [AnyHashable : Any]) {
-		
-		remainSelected = false
-		
-		if let linkDicationary = dictionary["link"] as? [AnyHashable : Any] {
-			link = StormLink(dictionary: linkDicationary)
-		} else {
-			link = nil
-		}
-		
-		if let titleDict = dictionary["title"] as? [AnyHashable : Any] {
-			title = StormLanguageController.shared.string(for: titleDict)
-		} else {
-			title = nil
-		}
-		
-		if let subtitleDict = dictionary["description"] as? [AnyHashable : Any] {
-			description = StormLanguageController.shared.string(for: subtitleDict)
-		} else {
-			description = nil
-		}
-		
-		image = StormGenerator.image(fromJSON: dictionary["image"])
+    
+    public required init?(dictionary: [AnyHashable : Any]) {
+        
+        remainSelected = false
+        
+        if let linkDicationary = dictionary["link"] as? [AnyHashable : Any] {
+            link = StormLink(dictionary: linkDicationary)
+        } else {
+            link = nil
+        }
+        
+        if let titleDict = dictionary["title"] as? [AnyHashable : Any] {
+            title = StormLanguageController.shared.string(for: titleDict)
+        } else {
+            title = nil
+        }
+        
+        if let subtitleDict = dictionary["description"] as? [AnyHashable : Any] {
+            description = StormLanguageController.shared.string(for: subtitleDict)
+        } else {
+            description = nil
+        }
+        
+        image = StormGenerator.image(fromJSON: dictionary["image"])
         
         if let imageDict = dictionary["image"] as? [AnyHashable : Any], let accessibilityLabelDictionary = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
             imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDictionary)
         }
-	}
-	
+    }
+    
     // This is empty, but must be left here in order for subclasses to implement the method and it still be called
-	public func configure(cell: UICollectionViewCell, at indexPath: IndexPath, in collectionViewController: CollectionViewController) {
-		
-	}
-
-	public var prototypeIdentifier: String? {
-		return nil
-	}
-	
-	public var remainSelected: Bool
-	
-	public func size(constrainedTo size: CGSize, in collectionView: UICollectionView) -> CGSize? {
-		return nil
-	}
+    public func configure(cell: UICollectionViewCell, at indexPath: IndexPath, in collectionViewController: CollectionViewController) {
+        
+    }
+    
+    public var prototypeIdentifier: String? {
+        return nil
+    }
+    
+    public var remainSelected: Bool
+    
+    public func size(constrainedTo size: CGSize, in collectionView: UICollectionView) -> CGSize? {
+        return nil
+    }
 }

--- a/ThunderCloud/GridItem.swift
+++ b/ThunderCloud/GridItem.swift
@@ -21,6 +21,9 @@ open class GridItem: CollectionItemDisplayable, StormObjectProtocol {
 	
 	/// The image to be displayed when displaying this item in a `UICollectionView`
 	open var image: UIImage?
+    
+    /// The accessibility label for the image displayed in this grid item
+    open var imageAccessibilityLabel: String?
 	
 	/// The title to be displayed when displaying this item in a `UICollectionView`
     public let title: String?
@@ -51,6 +54,10 @@ open class GridItem: CollectionItemDisplayable, StormObjectProtocol {
 		}
 		
 		image = StormGenerator.image(fromJSON: dictionary["image"])
+        
+        if let imageDict = dictionary["image"] as? [AnyHashable : Any], let accessibilityLabelDictionary = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
+            imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDictionary)
+        }
 	}
 	
     // This is empty, but must be left here in order for subclasses to implement the method and it still be called

--- a/ThunderCloud/ImageListItem.swift
+++ b/ThunderCloud/ImageListItem.swift
@@ -48,7 +48,7 @@ open class ImageListItem: ListItem {
         
         guard let imageCell = cell as? TableImageViewCell else { return }
         imageCell.cellImageView?.contentMode = .scaleAspectFill
-        imageCell.cellImageView?.accessibilityLabel = imageAccessibilityLabel
+        imageCell.cellImageView?.accessibilityLabel = stormImage?.accessibilityLabel
         imageCell.layer.masksToBounds = true
         
         if let imageHeight = imageHeight(constrainedTo: tableViewController.view.frame.width) {

--- a/ThunderCloud/ImageListItem.swift
+++ b/ThunderCloud/ImageListItem.swift
@@ -11,59 +11,59 @@ import ThunderTable
 
 /// A subclass of `ListItem` which displays an image in the table row at it's original aspect ratio
 open class ImageListItem: ListItem {
-	
-	override open var cellClass: UITableViewCell.Type? {
-		return TableImageViewCell.self
-	}
-	
-	override open var image: UIImage? {
-		get {
-			if super.image == nil {
-				
-				let bundle = Bundle(for: ImageListItem.self)
-				let transparentImage = UIImage(named: "transparent", in: bundle, compatibleWith: nil)
-				return transparentImage?.resizableImage(withCapInsets: .zero, resizingMode: .tile)
-			}
-			
-			return super.image
-		}
-		set {
-			super.image = newValue
-		}
-	}
-	
-	override open var estimatedHeight: CGFloat? {
-		return imageHeight(constrainedTo: UIScreen.main.bounds.width)
-	}
-	
-	open func imageHeight(constrainedTo width: CGFloat) -> CGFloat? {
-		guard let image = image else { return nil }
-		let aspectRatio = image.size.height / image.size.width
-		return aspectRatio * width
-	}
-	
-	override open func configure(cell: UITableViewCell, at indexPath: IndexPath, in tableViewController: TableViewController) {
-		
-		super.configure(cell: cell, at: indexPath, in: tableViewController)
-		
-		guard let imageCell = cell as? TableImageViewCell else { return }
-		imageCell.cellImageView?.contentMode = .scaleAspectFill
+    
+    override open var cellClass: UITableViewCell.Type? {
+        return TableImageViewCell.self
+    }
+    
+    override open var image: UIImage? {
+        get {
+            if super.image == nil {
+                
+                let bundle = Bundle(for: ImageListItem.self)
+                let transparentImage = UIImage(named: "transparent", in: bundle, compatibleWith: nil)
+                return transparentImage?.resizableImage(withCapInsets: .zero, resizingMode: .tile)
+            }
+            
+            return super.image
+        }
+        set {
+            super.image = newValue
+        }
+    }
+    
+    override open var estimatedHeight: CGFloat? {
+        return imageHeight(constrainedTo: UIScreen.main.bounds.width)
+    }
+    
+    open func imageHeight(constrainedTo width: CGFloat) -> CGFloat? {
+        guard let image = image else { return nil }
+        let aspectRatio = image.size.height / image.size.width
+        return aspectRatio * width
+    }
+    
+    override open func configure(cell: UITableViewCell, at indexPath: IndexPath, in tableViewController: TableViewController) {
+        
+        super.configure(cell: cell, at: indexPath, in: tableViewController)
+        
+        guard let imageCell = cell as? TableImageViewCell else { return }
+        imageCell.cellImageView?.contentMode = .scaleAspectFill
         imageCell.cellImageView?.accessibilityLabel = imageAccessibilityLabel
-		imageCell.layer.masksToBounds = true
-		
-		if let imageHeight = imageHeight(constrainedTo: tableViewController.view.frame.width) {
-			imageCell.imageHeightConstraint?.constant = imageHeight
-		}
-	}
-	
-	override open var accessoryType: UITableViewCell.AccessoryType? {
-		get {
-			return UITableViewCell.AccessoryType.none
-		}
-		set {}
-	}
-	
-	override open var selectionStyle: UITableViewCell.SelectionStyle? {
-		return UITableViewCell.SelectionStyle.none
-	}
+        imageCell.layer.masksToBounds = true
+        
+        if let imageHeight = imageHeight(constrainedTo: tableViewController.view.frame.width) {
+            imageCell.imageHeightConstraint?.constant = imageHeight
+        }
+    }
+    
+    override open var accessoryType: UITableViewCell.AccessoryType? {
+        get {
+            return UITableViewCell.AccessoryType.none
+        }
+        set {}
+    }
+    
+    override open var selectionStyle: UITableViewCell.SelectionStyle? {
+        return UITableViewCell.SelectionStyle.none
+    }
 }

--- a/ThunderCloud/ImageListItem.swift
+++ b/ThunderCloud/ImageListItem.swift
@@ -48,6 +48,7 @@ open class ImageListItem: ListItem {
 		
 		guard let imageCell = cell as? TableImageViewCell else { return }
 		imageCell.cellImageView?.contentMode = .scaleAspectFill
+        imageCell.cellImageView?.accessibilityLabel = imageAccessibilityLabel
 		imageCell.layer.masksToBounds = true
 		
 		if let imageHeight = imageHeight(constrainedTo: tableViewController.view.frame.width) {

--- a/ThunderCloud/ImageSelectionQuestion.swift
+++ b/ThunderCloud/ImageSelectionQuestion.swift
@@ -11,9 +11,14 @@ import UIKit
 /// An image selection option for an ImageSelectionQuestion
 public struct ImageOption {
 	
+    /// The title for the image option
 	public let title: String?
 	
+    /// The image to display to the user
 	public let image: UIImage?
+    
+    /// The accessibility label for the image
+    public let imageAccessibilityLabel: String?
 }
 
 
@@ -42,8 +47,13 @@ public class ImageSelectionQuestion: QuizQuestion {
 		
 		self.options = options.enumerated().map({ (index, option) -> ImageOption in
 			
-			let image: UIImage? = StormGenerator.image(fromJSON: imageDictionaries[index])
-			return ImageOption(title: StormLanguageController.shared.string(for: option), image: image)
+            let imageDict = imageDictionaries[index]
+			let image: UIImage? = StormGenerator.image(fromJSON: imageDict)
+            var imageAccessibilityLabel: String? = nil
+            if let accessibilityLabelDict = (imageDict as? [AnyHashable : Any])?["accessibilityLabel"] as? [AnyHashable : Any] {
+                imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
+            }
+            return ImageOption(title: StormLanguageController.shared.string(for: option), image: image, imageAccessibilityLabel: imageAccessibilityLabel)
 		})
 		
 		if let limit = dictionary["limit"] as? Int {

--- a/ThunderCloud/ImageSelectionQuestion.swift
+++ b/ThunderCloud/ImageSelectionQuestion.swift
@@ -44,16 +44,11 @@ public class ImageSelectionQuestion: QuizQuestion {
         
         guard options.count == imageDictionaries.count, options.count > 0 else { return nil }
         
-        
         self.options = options.enumerated().map({ (index, option) -> ImageOption in
             
             let imageDict = imageDictionaries[index]
-            let image: UIImage? = StormGenerator.image(fromJSON: imageDict)
-            var imageAccessibilityLabel: String? = nil
-            if let accessibilityLabelDict = (imageDict as? [AnyHashable : Any])?["accessibilityLabel"] as? [AnyHashable : Any] {
-                imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
-            }
-            return ImageOption(title: StormLanguageController.shared.string(for: option), image: image, imageAccessibilityLabel: imageAccessibilityLabel)
+            let image: StormImage? = StormGenerator.image(fromJSON: imageDict)
+            return ImageOption(title: StormLanguageController.shared.string(for: option), image: image?.image, imageAccessibilityLabel: image?.accessibilityLabel)
         })
         
         if let limit = dictionary["limit"] as? Int {

--- a/ThunderCloud/ImageSelectionQuestion.swift
+++ b/ThunderCloud/ImageSelectionQuestion.swift
@@ -10,12 +10,12 @@ import UIKit
 
 /// An image selection option for an ImageSelectionQuestion
 public struct ImageOption {
-	
+    
     /// The title for the image option
-	public let title: String?
-	
+    public let title: String?
+    
     /// The image to display to the user
-	public let image: UIImage?
+    public let image: UIImage?
     
     /// The accessibility label for the image
     public let imageAccessibilityLabel: String?
@@ -24,78 +24,78 @@ public struct ImageOption {
 
 /// The user is presented with a selection of images to choose from
 public class ImageSelectionQuestion: QuizQuestion {
-	
-	public let options: [ImageOption]
-	
-	public let correctAnswer: [Int]
-	
-	public let limit: Int
-	
-	public var answer: [Int] = [] {
-		didSet {
-			postNotification(notification: .answerChanged, object: self)
-		}
-	}
-	
-	override init?(dictionary: [AnyHashable : Any]) {
-		
-		guard let imageDictionaries = dictionary["images"] as? [Any] else { return nil }
-		guard let options = dictionary["options"] as? [[AnyHashable : Any]] else { return nil }
-		
-		guard options.count == imageDictionaries.count, options.count > 0 else { return nil }
-		
-		
-		self.options = options.enumerated().map({ (index, option) -> ImageOption in
-			
+    
+    public let options: [ImageOption]
+    
+    public let correctAnswer: [Int]
+    
+    public let limit: Int
+    
+    public var answer: [Int] = [] {
+        didSet {
+            postNotification(notification: .answerChanged, object: self)
+        }
+    }
+    
+    override init?(dictionary: [AnyHashable : Any]) {
+        
+        guard let imageDictionaries = dictionary["images"] as? [Any] else { return nil }
+        guard let options = dictionary["options"] as? [[AnyHashable : Any]] else { return nil }
+        
+        guard options.count == imageDictionaries.count, options.count > 0 else { return nil }
+        
+        
+        self.options = options.enumerated().map({ (index, option) -> ImageOption in
+            
             let imageDict = imageDictionaries[index]
-			let image: UIImage? = StormGenerator.image(fromJSON: imageDict)
+            let image: UIImage? = StormGenerator.image(fromJSON: imageDict)
             var imageAccessibilityLabel: String? = nil
             if let accessibilityLabelDict = (imageDict as? [AnyHashable : Any])?["accessibilityLabel"] as? [AnyHashable : Any] {
                 imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
             }
             return ImageOption(title: StormLanguageController.shared.string(for: option), image: image, imageAccessibilityLabel: imageAccessibilityLabel)
-		})
-		
-		if let limit = dictionary["limit"] as? Int {
-			self.limit = limit
-		} else {
-			limit = 0
-		}
-		
-		guard let answer = dictionary["answer"] as? [Int] else { return nil }
-		correctAnswer = answer
-		
-		super.init(dictionary: dictionary)
-	}
-	
+        })
+        
+        if let limit = dictionary["limit"] as? Int {
+            self.limit = limit
+        } else {
+            limit = 0
+        }
+        
+        guard let answer = dictionary["answer"] as? [Int] else { return nil }
+        correctAnswer = answer
+        
+        super.init(dictionary: dictionary)
+    }
+    
     override public var isCorrect: Bool {
-		get {
-			return correctAnswer.sorted(by: {$0>$1}) == answer.sorted(by: {$0>$1})
-		}
-		set {}
-	}
-	
+        get {
+            return correctAnswer.sorted(by: {$0>$1}) == answer.sorted(by: {$0>$1})
+        }
+        set {}
+    }
+    
     override public var answered: Bool {
-		get {
-			return limit > 0 ? (answer.count == limit) : (answer.count > 0)
-		}
-		set {}
-	}
-	
+        get {
+            return limit > 0 ? (answer.count == limit) : (answer.count > 0)
+        }
+        set {}
+    }
+    
     override public func reset() {
-		answer = []
-	}
-	
-	override func answerCorrectly() {
-		answer = correctAnswer
-	}
-	
-	override func answerRandomly() {
-		while answer.count < limit {
-			let answerOption = Int(arc4random_uniform(UInt32(options.count)))
-			if !answer.contains(answerOption) {
-				answer.append(answerOption)
-			}
-		}
-	}
+        answer = []
+    }
+    
+    override func answerCorrectly() {
+        answer = correctAnswer
+    }
+    
+    override func answerRandomly() {
+        while answer.count < limit {
+            let answerOption = Int(arc4random_uniform(UInt32(options.count)))
+            if !answer.contains(answerOption) {
+                answer.append(answerOption)
+            }
+        }
+    }
 }

--- a/ThunderCloud/ImageSliderQuestion.swift
+++ b/ThunderCloud/ImageSliderQuestion.swift
@@ -36,14 +36,10 @@ public class ImageSliderQuestion: QuizQuestion {
     override init?(dictionary: [AnyHashable : Any]) {
         
         if let imageObject = dictionary["image"], let image = StormGenerator.image(fromJSON: imageObject) {
-            sliderImage = image
+            sliderImage = image.image
+            imageAccessibilityLabel = image.accessibilityLabel
         } else {
             sliderImage = nil
-        }
-        
-        if let imageDict = dictionary["image"] as? [AnyHashable : Any], let accessibilityLabelDictionary = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
-            imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDictionary)
-        } else {
             imageAccessibilityLabel = nil
         }
         

--- a/ThunderCloud/ImageSliderQuestion.swift
+++ b/ThunderCloud/ImageSliderQuestion.swift
@@ -15,6 +15,9 @@ public class ImageSliderQuestion: QuizQuestion {
 	
 	/// (Cannot be called `image` due to Row conformance)
 	public let sliderImage: UIImage?
+    
+    /// The accessibility label for the image slider question
+    public let imageAccessibilityLabel: String?
 	
 	public let initialValue: Int?
 	
@@ -37,6 +40,12 @@ public class ImageSliderQuestion: QuizQuestion {
 		} else {
 			sliderImage = nil
 		}
+        
+        if let imageDict = dictionary["image"] as? [AnyHashable : Any], let accessibilityLabelDictionary = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
+            imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDictionary)
+        } else {
+            imageAccessibilityLabel = nil
+        }
 		
 		guard let answer = dictionary["answer"] as? Int else { return nil }
 		correctAnswer = answer

--- a/ThunderCloud/ImageSliderQuestion.swift
+++ b/ThunderCloud/ImageSliderQuestion.swift
@@ -10,85 +10,85 @@ import UIKit
 
 /// The user is presented with an image and a slider to choose a value
 public class ImageSliderQuestion: QuizQuestion {
-	
-	public let correctAnswer: Int
-	
-	/// (Cannot be called `image` due to Row conformance)
-	public let sliderImage: UIImage?
+    
+    public let correctAnswer: Int
+    
+    /// (Cannot be called `image` due to Row conformance)
+    public let sliderImage: UIImage?
     
     /// The accessibility label for the image slider question
     public let imageAccessibilityLabel: String?
-	
-	public let initialValue: Int?
-	
-	public let minValue: Int
-	
-	public let maxValue: Int
-	
-	public let unit: String?
-	
-	public var answer: Int? {
-		didSet {
-			postNotification(notification: .answerChanged, object: self)
-		}
-	}
-	
-	override init?(dictionary: [AnyHashable : Any]) {
-		
-		if let imageObject = dictionary["image"], let image = StormGenerator.image(fromJSON: imageObject) {
-			sliderImage = image
-		} else {
-			sliderImage = nil
-		}
+    
+    public let initialValue: Int?
+    
+    public let minValue: Int
+    
+    public let maxValue: Int
+    
+    public let unit: String?
+    
+    public var answer: Int? {
+        didSet {
+            postNotification(notification: .answerChanged, object: self)
+        }
+    }
+    
+    override init?(dictionary: [AnyHashable : Any]) {
+        
+        if let imageObject = dictionary["image"], let image = StormGenerator.image(fromJSON: imageObject) {
+            sliderImage = image
+        } else {
+            sliderImage = nil
+        }
         
         if let imageDict = dictionary["image"] as? [AnyHashable : Any], let accessibilityLabelDictionary = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
             imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDictionary)
         } else {
             imageAccessibilityLabel = nil
         }
-		
-		guard let answer = dictionary["answer"] as? Int else { return nil }
-		correctAnswer = answer
-		
-		guard let range = dictionary["range"] as? [AnyHashable : Any] else { return nil }
-		guard let min = range["start"] as? Int, let length = range["length"] as? Int else { return nil }
-		minValue = min
-		maxValue = min + length
-		
-		initialValue = dictionary["initialPosition"] as? Int
-		
-		if let unitDictionary = dictionary["unit"] as? [AnyHashable : Any] {
-			unit = StormLanguageController.shared.string(for: unitDictionary)
-		} else {
-			unit = nil
-		}
-		
-		super.init(dictionary: dictionary)
-	}
-	
+        
+        guard let answer = dictionary["answer"] as? Int else { return nil }
+        correctAnswer = answer
+        
+        guard let range = dictionary["range"] as? [AnyHashable : Any] else { return nil }
+        guard let min = range["start"] as? Int, let length = range["length"] as? Int else { return nil }
+        minValue = min
+        maxValue = min + length
+        
+        initialValue = dictionary["initialPosition"] as? Int
+        
+        if let unitDictionary = dictionary["unit"] as? [AnyHashable : Any] {
+            unit = StormLanguageController.shared.string(for: unitDictionary)
+        } else {
+            unit = nil
+        }
+        
+        super.init(dictionary: dictionary)
+    }
+    
     override public var isCorrect: Bool {
-		get {
-			return correctAnswer == answer
-		}
-		set {}
-	}
-	
+        get {
+            return correctAnswer == answer
+        }
+        set {}
+    }
+    
     override public var answered: Bool {
-		get {
-			return answer != nil
-		}
-		set {}
-	}
-	
+        get {
+            return answer != nil
+        }
+        set {}
+    }
+    
     override public func reset() {
-		answer = nil
-	}
-	
-	override func answerCorrectly() {
-		answer = correctAnswer
-	}
-	
-	override func answerRandomly() {
-		answer = Int(arc4random_uniform(UInt32(maxValue - minValue))) + minValue
-	}
+        answer = nil
+    }
+    
+    override func answerCorrectly() {
+        answer = correctAnswer
+    }
+    
+    override func answerRandomly() {
+        answer = Int(arc4random_uniform(UInt32(maxValue - minValue))) + minValue
+    }
 }

--- a/ThunderCloud/LinkCollectionCell.swift
+++ b/ThunderCloud/LinkCollectionCell.swift
@@ -12,75 +12,75 @@ import StoreKit
 /// A subclass of `CollectionCell` which displays the user a collection of links.
 /// Links in this collection view are displayed as their image
 class LinkCollectionCell: CollectionCell {
-	
-	/// The array of links to be shown in the collection view
-	var linkItems: [LinkCollectionItem]? {
-		didSet {
-			reload()
-		}
-	}
-	
+    
+    /// The array of links to be shown in the collection view
+    var linkItems: [LinkCollectionItem]? {
+        didSet {
+            reload()
+        }
+    }
+    
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         
-		super.init(style: style, reuseIdentifier: reuseIdentifier)
-		
-		let cellClass: AnyClass? = StormObjectFactory.shared.class(for: NSStringFromClass(LinkScrollerCollectionViewCell.self))
-		collectionView.register(cellClass ?? LinkScrollerCollectionViewCell.self, forCellWithReuseIdentifier: "Cell")
-		
-		pageControl.removeFromSuperview()
-	}
-	
-	required public init?(coder aDecoder: NSCoder) {
-		super.init(coder: aDecoder)
-	}
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        let cellClass: AnyClass? = StormObjectFactory.shared.class(for: NSStringFromClass(LinkScrollerCollectionViewCell.self))
+        collectionView.register(cellClass ?? LinkScrollerCollectionViewCell.self, forCellWithReuseIdentifier: "Cell")
+        
+        pageControl.removeFromSuperview()
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
 }
 
 //MARK: -
 //MARK: UICollectionViewDataSource
 //MARK: -
 extension LinkCollectionCell {
-	
-	func numberOfSections(in collectionView: UICollectionView) -> Int {
-		return 1
-	}
-	
-	override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-		return links?.count ?? 0
-	}
-	
-	override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-		
-		let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell", for: indexPath)
-		guard let links = linkItems, let linkCell = cell as? LinkScrollerCollectionViewCell else { return cell }
-		
-		let link = links[indexPath.row]
+    
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return 1
+    }
+    
+    override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return links?.count ?? 0
+    }
+    
+    override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell", for: indexPath)
+        guard let links = linkItems, let linkCell = cell as? LinkScrollerCollectionViewCell else { return cell }
+        
+        let link = links[indexPath.row]
         linkCell.imageView.accessibilityLabel = link.imageAccessibilityLabel
-		linkCell.imageView.image = link.image
-		
-		return linkCell
-	}
+        linkCell.imageView.image = link.image
+        
+        return linkCell
+    }
 }
 
 //MARK: -
 //MARK: UICollectionViewDelegateFlowLayout
 //MARK: -
 extension LinkCollectionCell {
-	
-	func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-		return CGSize(width: 80, height: bounds.size.height)
-	}
-	
-	func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-		return 0
-	}
-	
-	func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
-		return 0
-	}
-	
-	func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-		
-		guard let links = linkItems, let link = links[indexPath.item].link else { return }
-		parentViewController?.navigationController?.push(link: link)
-	}
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: 80, height: bounds.size.height)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return 0
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+        return 0
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        
+        guard let links = linkItems, let link = links[indexPath.item].link else { return }
+        parentViewController?.navigationController?.push(link: link)
+    }
 }

--- a/ThunderCloud/LinkCollectionCell.swift
+++ b/ThunderCloud/LinkCollectionCell.swift
@@ -54,8 +54,8 @@ extension LinkCollectionCell {
         guard let links = linkItems, let linkCell = cell as? LinkScrollerCollectionViewCell else { return cell }
         
         let link = links[indexPath.row]
-        linkCell.imageView.accessibilityLabel = link.imageAccessibilityLabel
-        linkCell.imageView.image = link.image
+        linkCell.imageView.accessibilityLabel = link.image?.accessibilityLabel
+        linkCell.imageView.image = link.image?.image
         
         return linkCell
     }

--- a/ThunderCloud/LinkCollectionCell.swift
+++ b/ThunderCloud/LinkCollectionCell.swift
@@ -54,6 +54,7 @@ extension LinkCollectionCell {
 		guard let links = linkItems, let linkCell = cell as? LinkScrollerCollectionViewCell else { return cell }
 		
 		let link = links[indexPath.row]
+        linkCell.imageView.accessibilityLabel = link.imageAccessibilityLabel
 		linkCell.imageView.image = link.image
 		
 		return linkCell

--- a/ThunderCloud/LinkCollectionItem.swift
+++ b/ThunderCloud/LinkCollectionItem.swift
@@ -15,10 +15,7 @@ open class LinkCollectionItem: StormObjectProtocol {
     let link: StormLink?
     
     /// The image to be displayed for the link
-    let image: UIImage?
-    
-    /// The accessibility label of the image for the link
-    let imageAccessibilityLabel: String?
+    let image: StormImage?
     
     /**
      Initializes a new instance of `TSCLinkCollectionItem` from a CMS representation
@@ -27,11 +24,6 @@ open class LinkCollectionItem: StormObjectProtocol {
     public required init?(dictionary: [AnyHashable : Any]) {
         
         image = StormGenerator.image(fromJSON:  dictionary["image"])
-        if let imageDict = dictionary["image"] as? [AnyHashable : Any], let accessibilityLabelDictionary = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
-            imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDictionary)
-        } else {
-            imageAccessibilityLabel = nil
-        }
         
         if let linkDictionary = dictionary["link"] as? [AnyHashable : Any] {
             link = StormLink(dictionary: linkDictionary)

--- a/ThunderCloud/LinkCollectionItem.swift
+++ b/ThunderCloud/LinkCollectionItem.swift
@@ -16,6 +16,9 @@ open class LinkCollectionItem: StormObjectProtocol {
 	
 	/// The image to be displayed for the link
 	let image: UIImage?
+    
+    /// The accessibility label of the image for the link
+    let imageAccessibilityLabel: String?
 	
 	/**
 	Initializes a new instance of `TSCLinkCollectionItem` from a CMS representation
@@ -24,6 +27,11 @@ open class LinkCollectionItem: StormObjectProtocol {
 	public required init?(dictionary: [AnyHashable : Any]) {
 		
 		image = StormGenerator.image(fromJSON:  dictionary["image"])
+        if let imageDict = dictionary["image"] as? [AnyHashable : Any], let accessibilityLabelDictionary = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
+            imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDictionary)
+        } else {
+            imageAccessibilityLabel = nil
+        }
 		
 		if let linkDictionary = dictionary["link"] as? [AnyHashable : Any] {
 			link = StormLink(dictionary: linkDictionary)

--- a/ThunderCloud/LinkCollectionItem.swift
+++ b/ThunderCloud/LinkCollectionItem.swift
@@ -10,33 +10,33 @@ import Foundation
 
 /// A model representation of a link to be shown in a `TSCAppScrollerItemViewCell`
 open class LinkCollectionItem: StormObjectProtocol {
-	
-	/// The link of the link item
-	let link: StormLink?
-	
-	/// The image to be displayed for the link
-	let image: UIImage?
+    
+    /// The link of the link item
+    let link: StormLink?
+    
+    /// The image to be displayed for the link
+    let image: UIImage?
     
     /// The accessibility label of the image for the link
     let imageAccessibilityLabel: String?
-	
-	/**
-	Initializes a new instance of `TSCLinkCollectionItem` from a CMS representation
-	@param dictionary The dictionary to initialize and populate the link from
-	*/
-	public required init?(dictionary: [AnyHashable : Any]) {
-		
-		image = StormGenerator.image(fromJSON:  dictionary["image"])
+    
+    /**
+     Initializes a new instance of `TSCLinkCollectionItem` from a CMS representation
+     @param dictionary The dictionary to initialize and populate the link from
+     */
+    public required init?(dictionary: [AnyHashable : Any]) {
+        
+        image = StormGenerator.image(fromJSON:  dictionary["image"])
         if let imageDict = dictionary["image"] as? [AnyHashable : Any], let accessibilityLabelDictionary = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
             imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDictionary)
         } else {
             imageAccessibilityLabel = nil
         }
-		
-		if let linkDictionary = dictionary["link"] as? [AnyHashable : Any] {
-			link = StormLink(dictionary: linkDictionary)
-		} else {
-			link = nil
-		}
-	}
+        
+        if let linkDictionary = dictionary["link"] as? [AnyHashable : Any] {
+            link = StormLink(dictionary: linkDictionary)
+        } else {
+            link = nil
+        }
+    }
 }

--- a/ThunderCloud/ListItem.swift
+++ b/ThunderCloud/ListItem.swift
@@ -151,6 +151,8 @@ open class ListItem: StormObject, Row {
             cell.accessoryType = .none
         }
         
+        cell.imageView?.accessibilityLabel = imageAccessibilityLabel
+        
         if let stormCell = cell as? StormTableViewCell {
             stormCell.parentViewController = tableViewController
             stormCell.links = embeddedLinks
@@ -183,6 +185,7 @@ open class ListItem: StormObject, Row {
             tableCell.cellTextLabel?.isHidden = title == nil || title!.isEmpty
             tableCell.cellDetailLabel?.isHidden = subtitle == nil || subtitle!.isEmpty
             
+            tableCell.cellImageView?.accessibilityLabel = imageAccessibilityLabel
             tableCell.cellImageView?.isHidden = image == nil && imageURL == nil
             tableCell.cellTextLabel?.font = ThemeManager.shared.theme.cellTitleFont
             tableCell.cellDetailLabel?.font = ThemeManager.shared.theme.cellDetailFont

--- a/ThunderCloud/ListItem.swift
+++ b/ThunderCloud/ListItem.swift
@@ -91,7 +91,13 @@ open class ListItem: StormObject, Row {
         get {
             return stormImage?.image
         }
-        set { }
+        set {
+            guard let _newValue = newValue else {
+                stormImage = nil
+                return
+            }
+            stormImage = StormImage(image: _newValue, accessibilityLabel: stormImage?.accessibilityLabel)
+        }
     }
     
     /// Given a Storm object dictionary, initialises a ListItem.

--- a/ThunderCloud/ListItem.swift
+++ b/ThunderCloud/ListItem.swift
@@ -48,6 +48,9 @@ open class ListItem: StormObject, Row {
     /// This is placed on the left hand side of the cell
     open var image: UIImage?
     
+    /// The accessibility label for the row's image
+    open var imageAccessibilityLabel: String?
+    
     /// The row's title text color
     open var titleTextColor: UIColor?
     
@@ -124,6 +127,9 @@ open class ListItem: StormObject, Row {
         }
         
         image = StormGenerator.image(fromJSON: dictionary["image"])
+        if let imageDict = dictionary["image"] as? [AnyHashable : Any], let accessibilityLabelDict = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
+            imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
+        }
         
         if let linkDicationary = dictionary["link"] as? [AnyHashable : Any] {
             link = StormLink(dictionary: linkDicationary, languageController: languageController)

--- a/ThunderCloud/ListItem.swift
+++ b/ThunderCloud/ListItem.swift
@@ -128,7 +128,7 @@ open class ListItem: StormObject, Row {
         
         image = StormGenerator.image(fromJSON: dictionary["image"])
         if let imageDict = dictionary["image"] as? [AnyHashable : Any], let accessibilityLabelDict = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
-            imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
+            imageAccessibilityLabel = languageController.string(for: accessibilityLabelDict)
         }
         
         if let linkDicationary = dictionary["link"] as? [AnyHashable : Any] {

--- a/ThunderCloud/ListItem.swift
+++ b/ThunderCloud/ListItem.swift
@@ -46,10 +46,7 @@ open class ListItem: StormObject, Row {
     
     /// The image for the row
     /// This is placed on the left hand side of the cell
-    open var image: UIImage?
-    
-    /// The accessibility label for the row's image
-    open var imageAccessibilityLabel: String?
+    open var stormImage: StormImage?
     
     /// The row's title text color
     open var titleTextColor: UIColor?
@@ -90,6 +87,13 @@ open class ListItem: StormObject, Row {
         return nil
     }
     
+    public var image: UIImage? {
+        get {
+            return stormImage?.image
+        }
+        set { }
+    }
+    
     /// Given a Storm object dictionary, initialises a ListItem.
     ///
     /// - Parameter dictionary: A Storm object dictionary.
@@ -126,10 +130,7 @@ open class ListItem: StormObject, Row {
             subtitle = languageController.string(for: subtitleDict)
         }
         
-        image = StormGenerator.image(fromJSON: dictionary["image"])
-        if let imageDict = dictionary["image"] as? [AnyHashable : Any], let accessibilityLabelDict = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
-            imageAccessibilityLabel = languageController.string(for: accessibilityLabelDict)
-        }
+        stormImage = StormGenerator.image(fromJSON: dictionary["image"])
         
         if let linkDicationary = dictionary["link"] as? [AnyHashable : Any] {
             link = StormLink(dictionary: linkDicationary, languageController: languageController)
@@ -151,7 +152,7 @@ open class ListItem: StormObject, Row {
             cell.accessoryType = .none
         }
         
-        cell.imageView?.accessibilityLabel = imageAccessibilityLabel
+        cell.imageView?.accessibilityLabel = stormImage?.accessibilityLabel
         
         if let stormCell = cell as? StormTableViewCell {
             stormCell.parentViewController = tableViewController
@@ -185,7 +186,7 @@ open class ListItem: StormObject, Row {
             tableCell.cellTextLabel?.isHidden = title == nil || title!.isEmpty
             tableCell.cellDetailLabel?.isHidden = subtitle == nil || subtitle!.isEmpty
             
-            tableCell.cellImageView?.accessibilityLabel = imageAccessibilityLabel
+            tableCell.cellImageView?.accessibilityLabel = stormImage?.accessibilityLabel
             tableCell.cellImageView?.isHidden = image == nil && imageURL == nil
             tableCell.cellTextLabel?.font = ThemeManager.shared.theme.cellTitleFont
             tableCell.cellDetailLabel?.font = ThemeManager.shared.theme.cellDetailFont

--- a/ThunderCloud/Placeholder.swift
+++ b/ThunderCloud/Placeholder.swift
@@ -28,7 +28,12 @@ struct Placeholder {
 			description = nil
 		}
 		
-		image = StormGenerator.image(fromJSON: dictionary["placeholderImage"] )
+		image = StormGenerator.image(fromJSON: dictionary["placeholderImage"])
+        if let accessibilityLabelDict = dictionary["accessibilityLabel"] as? [AnyHashable : Any] {
+            imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
+        } else {
+            imageAccessibilityLabel = nil
+        }
 	}
 	
 	/// The tab's title
@@ -39,4 +44,7 @@ struct Placeholder {
 	
 	/// The tab icon image
 	let image: UIImage?
+    
+    /// The tab icon accessibility label
+    let imageAccessibilityLabel: String?
 }

--- a/ThunderCloud/Placeholder.swift
+++ b/ThunderCloud/Placeholder.swift
@@ -29,11 +29,6 @@ struct Placeholder {
         }
         
         image = StormGenerator.image(fromJSON: dictionary["placeholderImage"])
-        if let accessibilityLabelDict = dictionary["accessibilityLabel"] as? [AnyHashable : Any] {
-            imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
-        } else {
-            imageAccessibilityLabel = nil
-        }
     }
     
     /// The tab's title
@@ -43,8 +38,5 @@ struct Placeholder {
     let description: String?
     
     /// The tab icon image
-    let image: UIImage?
-    
-    /// The tab icon accessibility label
-    let imageAccessibilityLabel: String?
+    let image: StormImage?
 }

--- a/ThunderCloud/Placeholder.swift
+++ b/ThunderCloud/Placeholder.swift
@@ -10,40 +10,40 @@ import UIKit
 
 /// A representation of a `UITabBarItem` for usage in `AccordionTabBarViewController`
 struct Placeholder {
-	
-	/// Initializes a new placeholder with a dictionary
-	///
-	/// - Parameter dictionary: Dictionary representation of the placeholder
-	init(dictionary: [AnyHashable : Any]) {
-		
-		if let titleDictionary = dictionary["title"] as? [AnyHashable : Any] {
-			title = StormLanguageController.shared.string(for: titleDictionary)
-		} else {
-			title = nil
-		}
-		
-		if let descriptionDictionary = dictionary["description"] as? [AnyHashable : Any] {
-			description = StormLanguageController.shared.string(for: descriptionDictionary)
-		} else {
-			description = nil
-		}
-		
-		image = StormGenerator.image(fromJSON: dictionary["placeholderImage"])
+    
+    /// Initializes a new placeholder with a dictionary
+    ///
+    /// - Parameter dictionary: Dictionary representation of the placeholder
+    init(dictionary: [AnyHashable : Any]) {
+        
+        if let titleDictionary = dictionary["title"] as? [AnyHashable : Any] {
+            title = StormLanguageController.shared.string(for: titleDictionary)
+        } else {
+            title = nil
+        }
+        
+        if let descriptionDictionary = dictionary["description"] as? [AnyHashable : Any] {
+            description = StormLanguageController.shared.string(for: descriptionDictionary)
+        } else {
+            description = nil
+        }
+        
+        image = StormGenerator.image(fromJSON: dictionary["placeholderImage"])
         if let accessibilityLabelDict = dictionary["accessibilityLabel"] as? [AnyHashable : Any] {
             imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
         } else {
             imageAccessibilityLabel = nil
         }
-	}
-	
-	/// The tab's title
-	let title: String?
-	
-	/// The tab's description
-	let description: String?
-	
-	/// The tab icon image
-	let image: UIImage?
+    }
+    
+    /// The tab's title
+    let title: String?
+    
+    /// The tab's description
+    let description: String?
+    
+    /// The tab icon image
+    let image: UIImage?
     
     /// The tab icon accessibility label
     let imageAccessibilityLabel: String?

--- a/ThunderCloud/PlaceholderViewController.swift
+++ b/ThunderCloud/PlaceholderViewController.swift
@@ -37,8 +37,8 @@ open class PlaceholderViewController: UIViewController {
             navigationController?.navigationBar.setNeedsDisplay()
             
             descriptionLabel.text = placeholder?.description
-            imageView.image = placeholder?.image
-            imageView.accessibilityLabel = placeholder?.imageAccessibilityLabel
+            imageView.image = placeholder?.image?.image
+            imageView.accessibilityLabel = placeholder?.image?.accessibilityLabel
             
             if isViewLoaded {
                 view.setNeedsLayout()
@@ -69,8 +69,8 @@ open class PlaceholderViewController: UIViewController {
         
         view.addSubview(descriptionLabel)
         
-        imageView.image = placeholder?.image
-        imageView.accessibilityLabel = placeholder?.imageAccessibilityLabel
+        imageView.image = placeholder?.image?.image
+        imageView.accessibilityLabel = placeholder?.image?.accessibilityLabel
         imageView.frame = CGRect(x: 0, y: 0, width: 150, height: 150)
         imageView.contentMode = .scaleAspectFill
         

--- a/ThunderCloud/PlaceholderViewController.swift
+++ b/ThunderCloud/PlaceholderViewController.swift
@@ -38,6 +38,7 @@ open class PlaceholderViewController: UIViewController {
 			
 			descriptionLabel.text = placeholder?.description
 			imageView.image = placeholder?.image
+            imageView.accessibilityLabel = placeholder?.imageAccessibilityLabel
 			
 			if isViewLoaded {
 				view.setNeedsLayout()
@@ -69,6 +70,7 @@ open class PlaceholderViewController: UIViewController {
 		view.addSubview(descriptionLabel)
 		
 		imageView.image = placeholder?.image
+        imageView.accessibilityLabel = placeholder?.imageAccessibilityLabel
 		imageView.frame = CGRect(x: 0, y: 0, width: 150, height: 150)
 		imageView.contentMode = .scaleAspectFill
 		

--- a/ThunderCloud/PlaceholderViewController.swift
+++ b/ThunderCloud/PlaceholderViewController.swift
@@ -11,87 +11,87 @@ import ThunderTable
 
 /// A placeholder `UIViewController` which is shown in the detail of a `AccordionTabBarViewController` when there is nothing else to show in the detail view
 open class PlaceholderViewController: UIViewController {
-
-	private let titleLabel = UILabel()
-	
-	private let descriptionLabel = UILabel()
-	
-	private let imageView = UIImageView()
-	
-	init(placeholder: Placeholder) {
-		
-		super.init(nibName: nil, bundle: nil)
-		self.placeholder = placeholder
-	}
-	
-	required public init?(coder aDecoder: NSCoder) {
-		super.init(coder: aDecoder)
-	}
-	
-	var placeholder: Placeholder? {
-		didSet {
-			
-			titleLabel.text = placeholder?.title
-			title = placeholder?.title
-			
-			navigationController?.navigationBar.setNeedsDisplay()
-			
-			descriptionLabel.text = placeholder?.description
-			imageView.image = placeholder?.image
+    
+    private let titleLabel = UILabel()
+    
+    private let descriptionLabel = UILabel()
+    
+    private let imageView = UIImageView()
+    
+    init(placeholder: Placeholder) {
+        
+        super.init(nibName: nil, bundle: nil)
+        self.placeholder = placeholder
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    var placeholder: Placeholder? {
+        didSet {
+            
+            titleLabel.text = placeholder?.title
+            title = placeholder?.title
+            
+            navigationController?.navigationBar.setNeedsDisplay()
+            
+            descriptionLabel.text = placeholder?.description
+            imageView.image = placeholder?.image
             imageView.accessibilityLabel = placeholder?.imageAccessibilityLabel
-			
-			if isViewLoaded {
-				view.setNeedsLayout()
-			}
-		}
-	}
-	
-	open override func viewDidLoad() {
-		
-		super.viewDidLoad()
-		
-		title = placeholder?.title
-		
-		titleLabel.text = placeholder?.title
-		titleLabel.font = ThemeManager.shared.theme.dynamicFont(ofSize: 36, textStyle: .title1)
-		titleLabel.textColor = UIColor(hexString: "4b4949")
-		titleLabel.textAlignment = .center
-		titleLabel.backgroundColor = .clear
-		
-		view.addSubview(titleLabel)
-		
-		descriptionLabel.text = placeholder?.description
-		descriptionLabel.font = ThemeManager.shared.theme.dynamicFont(ofSize: 20, textStyle: .subheadline)
-		descriptionLabel.textColor = UIColor(hexString: "7b7b7f")
-		descriptionLabel.textAlignment = .center
-		descriptionLabel.numberOfLines = 0
-		descriptionLabel.backgroundColor = .clear
-		
-		view.addSubview(descriptionLabel)
-		
-		imageView.image = placeholder?.image
+            
+            if isViewLoaded {
+                view.setNeedsLayout()
+            }
+        }
+    }
+    
+    open override func viewDidLoad() {
+        
+        super.viewDidLoad()
+        
+        title = placeholder?.title
+        
+        titleLabel.text = placeholder?.title
+        titleLabel.font = ThemeManager.shared.theme.dynamicFont(ofSize: 36, textStyle: .title1)
+        titleLabel.textColor = UIColor(hexString: "4b4949")
+        titleLabel.textAlignment = .center
+        titleLabel.backgroundColor = .clear
+        
+        view.addSubview(titleLabel)
+        
+        descriptionLabel.text = placeholder?.description
+        descriptionLabel.font = ThemeManager.shared.theme.dynamicFont(ofSize: 20, textStyle: .subheadline)
+        descriptionLabel.textColor = UIColor(hexString: "7b7b7f")
+        descriptionLabel.textAlignment = .center
+        descriptionLabel.numberOfLines = 0
+        descriptionLabel.backgroundColor = .clear
+        
+        view.addSubview(descriptionLabel)
+        
+        imageView.image = placeholder?.image
         imageView.accessibilityLabel = placeholder?.imageAccessibilityLabel
-		imageView.frame = CGRect(x: 0, y: 0, width: 150, height: 150)
-		imageView.contentMode = .scaleAspectFill
-		
-		view.addSubview(imageView)
-		
-		view.backgroundColor = ThemeManager.shared.theme.backgroundColor
-	}
-	
-	open override func viewWillLayoutSubviews() {
-		
-		super.viewWillLayoutSubviews()
-		
-		imageView.center = CGPoint(x: view.frame.width/2, y: view.frame.height/2 - imageView.frame.height/2)
-		
-		let width = view.frame.width/2
-		
-		titleLabel.frame = CGRect(x: width/2, y: view.frame.height/2, width: width, height: 50)
-		
-		let constrainedSize = CGSize(width: width, height: .greatestFiniteMagnitude)
-		let descriptionLabelSize = descriptionLabel.sizeThatFits(constrainedSize)
-		
-		descriptionLabel.frame = CGRect(x: (view.frame.width - descriptionLabelSize.width) / 2, y: titleLabel.frame.maxY + 15, width: descriptionLabelSize.width, height: descriptionLabelSize.height)
-	}
+        imageView.frame = CGRect(x: 0, y: 0, width: 150, height: 150)
+        imageView.contentMode = .scaleAspectFill
+        
+        view.addSubview(imageView)
+        
+        view.backgroundColor = ThemeManager.shared.theme.backgroundColor
+    }
+    
+    open override func viewWillLayoutSubviews() {
+        
+        super.viewWillLayoutSubviews()
+        
+        imageView.center = CGPoint(x: view.frame.width/2, y: view.frame.height/2 - imageView.frame.height/2)
+        
+        let width = view.frame.width/2
+        
+        titleLabel.frame = CGRect(x: width/2, y: view.frame.height/2, width: width, height: 50)
+        
+        let constrainedSize = CGSize(width: width, height: .greatestFiniteMagnitude)
+        let descriptionLabelSize = descriptionLabel.sizeThatFits(constrainedSize)
+        
+        descriptionLabel.frame = CGRect(x: (view.frame.width - descriptionLabelSize.width) / 2, y: titleLabel.frame.maxY + 15, width: descriptionLabelSize.width, height: descriptionLabelSize.height)
+    }
 }

--- a/ThunderCloud/QuizAreaSelectionViewController.swift
+++ b/ThunderCloud/QuizAreaSelectionViewController.swift
@@ -32,7 +32,7 @@ open class QuizAreaSelectionViewController: UIViewController {
 			return
 		}
         
-		let imageAnalyser = ImageColorAnalyzer(image: question.selectionImage)
+		let imageAnalyser = ImageColorAnalyzer(image: question.selectionImage.image)
 		imageAnalyser.analyze()
 		circleColor = imageAnalyser.detailColor ?? .black
 	}
@@ -44,9 +44,9 @@ open class QuizAreaSelectionViewController: UIViewController {
             return
         }
         
-        imageView.accessibilityLabel = question.imageAccessibilityLabel
-        imageView.image = question.selectionImage
-        let imageAspect = question.selectionImage.size.height / question.selectionImage.size.width
+        imageView.accessibilityLabel = question.selectionImage.accessibilityLabel
+        imageView.image = question.selectionImage.image
+        let imageAspect = question.selectionImage.image.size.height / question.selectionImage.image.size.width
         heightConstraint.constant = imageAspect * imageView.frame.width
     }
 	

--- a/ThunderCloud/QuizAreaSelectionViewController.swift
+++ b/ThunderCloud/QuizAreaSelectionViewController.swift
@@ -44,6 +44,7 @@ open class QuizAreaSelectionViewController: UIViewController {
             return
         }
         
+        imageView.accessibilityLabel = question.imageAccessibilityLabel
         imageView.image = question.selectionImage
         let imageAspect = question.selectionImage.size.height / question.selectionImage.size.width
         heightConstraint.constant = imageAspect * imageView.frame.width

--- a/ThunderCloud/QuizBadgeScrollerViewCell.swift
+++ b/ThunderCloud/QuizBadgeScrollerViewCell.swift
@@ -177,6 +177,7 @@ extension QuizBadgeScrollerViewCell {
             return cell
         }
         
+        badgeCell.badgeImageView.accessibilityLabel = badge.iconAccessibilityLabel
         badgeCell.badgeImageView.image = badge.icon
         
         if let badgeId = badge.id, BadgeController.shared.hasEarntBadge(with: badgeId) {

--- a/ThunderCloud/QuizGridItem.swift
+++ b/ThunderCloud/QuizGridItem.swift
@@ -24,8 +24,8 @@ open class QuizGridItem: StandardGridItem {
 		
 		super.init(dictionary: dictionary)
 		
-		if let badgeId = badgeId, let badge = BadgeController.shared.badge(for: badgeId) {
-			image = badge.icon
+		if let badgeId = badgeId, let badge = BadgeController.shared.badge(for: badgeId), let badgeIcon = badge.icon {
+			image = StormImage(image: badgeIcon, accessibilityLabel: badge.iconAccessibilityLabel)
 		}
 	}
     

--- a/ThunderCloud/QuizImageSelectionViewController.swift
+++ b/ThunderCloud/QuizImageSelectionViewController.swift
@@ -19,6 +19,7 @@ extension ImageOption: CollectionItemDisplayable {
     public func configure(cell: UICollectionViewCell, at indexPath: IndexPath, in collectionViewController: CollectionViewController) {
         guard let imageSelectionCell = cell as? ImageSelectionCollectionViewCell else { return }
         
+        imageSelectionCell.imageView.accessibilityLabel = imageAccessibilityLabel
         imageSelectionCell.imageView.image = image
         imageSelectionCell.label.isHidden = title == nil
         imageSelectionCell.gradientView.isHidden = title == nil

--- a/ThunderCloud/QuizSliderViewController.swift
+++ b/ThunderCloud/QuizSliderViewController.swift
@@ -10,53 +10,53 @@ import UIKit
 import ThunderTable
 
 class QuizSliderViewController: UIViewController {
-
-	@IBOutlet weak var imageView: ImageView!
-	
-	@IBOutlet weak var amountLabel: UILabel!
-	
-	@IBOutlet weak var slider: UISlider!
-	
-	@IBOutlet weak var heightConstraint: NSLayoutConstraint!
-	
-	var question: ImageSliderQuestion?
-	
-	override func viewDidLoad() {
-		
-		super.viewDidLoad()
-		
-		view.backgroundColor = ThemeManager.shared.theme.backgroundColor
-		
-		guard let question = question else {
-			return
-		}
-		
-		if let image = question.sliderImage {
-		
+    
+    @IBOutlet weak var imageView: ImageView!
+    
+    @IBOutlet weak var amountLabel: UILabel!
+    
+    @IBOutlet weak var slider: UISlider!
+    
+    @IBOutlet weak var heightConstraint: NSLayoutConstraint!
+    
+    var question: ImageSliderQuestion?
+    
+    override func viewDidLoad() {
+        
+        super.viewDidLoad()
+        
+        view.backgroundColor = ThemeManager.shared.theme.backgroundColor
+        
+        guard let question = question else {
+            return
+        }
+        
+        if let image = question.sliderImage {
+            
             imageView.accessibilityLabel = question.imageAccessibilityLabel
-			imageView.image = image
-			let imageAspect = image.size.height / image.size.width
-			heightConstraint.constant = imageAspect * imageView.frame.width
-		} else {
-			heightConstraint.constant = 0
-		}
-		
-		slider.minimumValue = Float(question.minValue)
-		slider.maximumValue = Float(question.maxValue)
-		
-		amountLabel.text = "\(Int(slider.value))"
-		
-		if let initalValue = question.initialValue {
-			slider.value = Float(initalValue)
-		}
-		
-		amountLabel.text = "\(Int(slider.value)) \(question.unit ?? "")"
-		slider.isUserInteractionEnabled = true
-	}
-	
-	@IBAction func handleSlider(_ sender: UISlider) {
-		
-		amountLabel.text = "\(Int(slider.value)) \(question?.unit ?? "")"
-		question?.answer = Int(slider.value)
-	}
+            imageView.image = image
+            let imageAspect = image.size.height / image.size.width
+            heightConstraint.constant = imageAspect * imageView.frame.width
+        } else {
+            heightConstraint.constant = 0
+        }
+        
+        slider.minimumValue = Float(question.minValue)
+        slider.maximumValue = Float(question.maxValue)
+        
+        amountLabel.text = "\(Int(slider.value))"
+        
+        if let initalValue = question.initialValue {
+            slider.value = Float(initalValue)
+        }
+        
+        amountLabel.text = "\(Int(slider.value)) \(question.unit ?? "")"
+        slider.isUserInteractionEnabled = true
+    }
+    
+    @IBAction func handleSlider(_ sender: UISlider) {
+        
+        amountLabel.text = "\(Int(slider.value)) \(question?.unit ?? "")"
+        question?.answer = Int(slider.value)
+    }
 }

--- a/ThunderCloud/QuizSliderViewController.swift
+++ b/ThunderCloud/QuizSliderViewController.swift
@@ -33,6 +33,7 @@ class QuizSliderViewController: UIViewController {
 		
 		if let image = question.sliderImage {
 		
+            imageView.accessibilityLabel = question.imageAccessibilityLabel
 			imageView.image = image
 			let imageAspect = image.size.height / image.size.width
 			heightConstraint.constant = imageAspect * imageView.frame.width

--- a/ThunderCloud/Spotlight.swift
+++ b/ThunderCloud/Spotlight.swift
@@ -11,6 +11,9 @@ import UIKit
 /// A model representation of a spotlight that will be displayed inside a view.
 /// This object will usually be part of an array which is cycled through when displayed
 open class Spotlight: StormObject {
+    
+    /// A string that is used as the accessibility label for the spotlight
+    open var imageAccessibilityLabel: String?
 	
 	/// A `UIImage` that is displayed for the spotlight
 	open var image: UIImage?
@@ -39,6 +42,12 @@ open class Spotlight: StormObject {
 		if let delay = delay {
 			self.delay = delay / 1000
 		}
+        
+        if let accessibilityLabelDictionary = dictionary["accessibilityLabel"] as? [AnyHashable : Any] {
+            imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDictionary)
+        } else if let imageDict = dictionary["image"] as? [AnyHashable : Any], let accessibilityLabelDictionary = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
+            imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDictionary)
+        }
 		
 		if let spotlightTextDictionary = dictionary["text"] as? [AnyHashable : Any] {
 			spotlightText = StormLanguageController.shared.string(for: spotlightTextDictionary)

--- a/ThunderCloud/Spotlight.swift
+++ b/ThunderCloud/Spotlight.swift
@@ -14,47 +14,47 @@ open class Spotlight: StormObject {
     
     /// A string that is used as the accessibility label for the spotlight
     open var imageAccessibilityLabel: String?
-	
-	/// A `UIImage` that is displayed for the spotlight
-	open var image: UIImage?
-	
-	/// A `StormLink` that is used to perform an action when an item is selected
-	open var link: StormLink?
-	
-	/// How long the item should be displayed on screen for
-	open var delay: TimeInterval?
-	
-	/// A string of text which is displayed across the center of the spotlight item
-	open var spotlightText: String?
-
-	required public init(dictionary: [AnyHashable : Any]) {
-		
-		super.init(dictionary: dictionary)
-		
-		image = StormGenerator.image(fromJSON: dictionary["image"])
-		
-		//This is for legacy spotlight image support
-		if image == nil {
-			image = StormGenerator.image(fromJSON: dictionary)
-		}
-		
-		delay = dictionary["delay"] as? TimeInterval
-		if let delay = delay {
-			self.delay = delay / 1000
-		}
+    
+    /// A `UIImage` that is displayed for the spotlight
+    open var image: UIImage?
+    
+    /// A `StormLink` that is used to perform an action when an item is selected
+    open var link: StormLink?
+    
+    /// How long the item should be displayed on screen for
+    open var delay: TimeInterval?
+    
+    /// A string of text which is displayed across the center of the spotlight item
+    open var spotlightText: String?
+    
+    required public init(dictionary: [AnyHashable : Any]) {
+        
+        super.init(dictionary: dictionary)
+        
+        image = StormGenerator.image(fromJSON: dictionary["image"])
+        
+        //This is for legacy spotlight image support
+        if image == nil {
+            image = StormGenerator.image(fromJSON: dictionary)
+        }
+        
+        delay = dictionary["delay"] as? TimeInterval
+        if let delay = delay {
+            self.delay = delay / 1000
+        }
         
         if let accessibilityLabelDictionary = dictionary["accessibilityLabel"] as? [AnyHashable : Any] {
             imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDictionary)
         } else if let imageDict = dictionary["image"] as? [AnyHashable : Any], let accessibilityLabelDictionary = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
             imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDictionary)
         }
-		
-		if let spotlightTextDictionary = dictionary["text"] as? [AnyHashable : Any] {
-			spotlightText = StormLanguageController.shared.string(for: spotlightTextDictionary)
-		}
-		
-		if let linkDictionary = dictionary["link"] as? [AnyHashable : Any], linkDictionary["destination"] != nil {
-			link = StormLink(dictionary: linkDictionary)
-		}
-	}
+        
+        if let spotlightTextDictionary = dictionary["text"] as? [AnyHashable : Any] {
+            spotlightText = StormLanguageController.shared.string(for: spotlightTextDictionary)
+        }
+        
+        if let linkDictionary = dictionary["link"] as? [AnyHashable : Any], linkDictionary["destination"] != nil {
+            link = StormLink(dictionary: linkDictionary)
+        }
+    }
 }

--- a/ThunderCloud/Spotlight.swift
+++ b/ThunderCloud/Spotlight.swift
@@ -12,11 +12,8 @@ import UIKit
 /// This object will usually be part of an array which is cycled through when displayed
 open class Spotlight: StormObject {
     
-    /// A string that is used as the accessibility label for the spotlight
-    open var imageAccessibilityLabel: String?
-    
-    /// A `UIImage` that is displayed for the spotlight
-    open var image: UIImage?
+    /// A `StormImage` that is displayed for the spotlight
+    open var image: StormImage?
     
     /// A `StormLink` that is used to perform an action when an item is selected
     open var link: StormLink?
@@ -41,12 +38,6 @@ open class Spotlight: StormObject {
         delay = dictionary["delay"] as? TimeInterval
         if let delay = delay {
             self.delay = delay / 1000
-        }
-        
-        if let accessibilityLabelDictionary = dictionary["accessibilityLabel"] as? [AnyHashable : Any] {
-            imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDictionary)
-        } else if let imageDict = dictionary["image"] as? [AnyHashable : Any], let accessibilityLabelDictionary = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
-            imageAccessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDictionary)
         }
         
         if let spotlightTextDictionary = dictionary["text"] as? [AnyHashable : Any] {

--- a/ThunderCloud/SpotlightListItem.swift
+++ b/ThunderCloud/SpotlightListItem.swift
@@ -58,7 +58,7 @@ open class SpotlightListItem: ListItem, SpotlightListItemCellDelegate {
     
     open func imageHeight(constrainedTo width: CGFloat) -> CGFloat? {
         guard let image = spotlights?.first?.image else { return nil }
-        let aspectRatio = image.size.height / image.size.width
+        let aspectRatio = image.image.size.height / image.image.size.width
         return aspectRatio * width
     }
     

--- a/ThunderCloud/SpotlightListItemCell.swift
+++ b/ThunderCloud/SpotlightListItemCell.swift
@@ -125,6 +125,7 @@ open class SpotlightListItemCell: StormTableViewCell {
     open func configure(spotlightCell: SpotlightImageCollectionViewCell, with spotlight: Spotlight) {
         
         spotlightCell.imageView.image = spotlight.image
+        spotlightCell.imageView.accessibilityLabel = spotlight.imageAccessibilityLabel
         spotlightCell.titleLabel.text = spotlight.spotlightText
         spotlightCell.titleLabel.font = ThemeManager.shared.theme.dynamicFont(ofSize: 22, textStyle: .title2, weight: .bold)
         spotlightCell.titleLabel.shadowColor = UIColor.black.withAlphaComponent(0.5)

--- a/ThunderCloud/SpotlightListItemCell.swift
+++ b/ThunderCloud/SpotlightListItemCell.swift
@@ -124,8 +124,8 @@ open class SpotlightListItemCell: StormTableViewCell {
     
     open func configure(spotlightCell: SpotlightImageCollectionViewCell, with spotlight: Spotlight) {
         
-        spotlightCell.imageView.image = spotlight.image
-        spotlightCell.imageView.accessibilityLabel = spotlight.imageAccessibilityLabel
+        spotlightCell.imageView.image = spotlight.image?.image
+        spotlightCell.imageView.accessibilityLabel = spotlight.image?.accessibilityLabel
         spotlightCell.titleLabel.text = spotlight.spotlightText
         spotlightCell.titleLabel.font = ThemeManager.shared.theme.dynamicFont(ofSize: 22, textStyle: .title2, weight: .bold)
         spotlightCell.titleLabel.shadowColor = UIColor.black.withAlphaComponent(0.5)

--- a/ThunderCloud/StandardGridItem.swift
+++ b/ThunderCloud/StandardGridItem.swift
@@ -11,21 +11,21 @@ import ThunderCollection
 
 /// `StandardGridItem` is a subclass of `GridItem` it represents a row with an item with a title, description and image. It is an adapter for the object in the CMS. All logic is done on it's super.
 open class StandardGridItem: GridItem {
-
-	open override var cellClass: UICollectionViewCell.Type? {
-		return StandardGridItemCell.self
-	}
-	
-	open override func configure(cell: UICollectionViewCell, at indexPath: IndexPath, in collectionViewController: CollectionViewController) {
-		
-		guard let standardCell = cell as? StandardGridItemCell else { return }
-		
+    
+    open override var cellClass: UICollectionViewCell.Type? {
+        return StandardGridItemCell.self
+    }
+    
+    open override func configure(cell: UICollectionViewCell, at indexPath: IndexPath, in collectionViewController: CollectionViewController) {
+        
+        guard let standardCell = cell as? StandardGridItemCell else { return }
+        
         standardCell.imageView?.accessibilityLabel = imageAccessibilityLabel
-		standardCell.imageView?.isHidden = image == nil
-		standardCell.imageView?.image = image
-		standardCell.titleLabel?.isHidden = title == nil || title!.isEmpty
-		standardCell.titleLabel?.text = title
-		standardCell.subtitleLabel?.isHidden = description == nil || description!.isEmpty
-		standardCell.subtitleLabel?.text = description
-	}
+        standardCell.imageView?.isHidden = image == nil
+        standardCell.imageView?.image = image
+        standardCell.titleLabel?.isHidden = title == nil || title!.isEmpty
+        standardCell.titleLabel?.text = title
+        standardCell.subtitleLabel?.isHidden = description == nil || description!.isEmpty
+        standardCell.subtitleLabel?.text = description
+    }
 }

--- a/ThunderCloud/StandardGridItem.swift
+++ b/ThunderCloud/StandardGridItem.swift
@@ -20,6 +20,7 @@ open class StandardGridItem: GridItem {
 		
 		guard let standardCell = cell as? StandardGridItemCell else { return }
 		
+        standardCell.imageView?.accessibilityLabel = imageAccessibilityLabel
 		standardCell.imageView?.isHidden = image == nil
 		standardCell.imageView?.image = image
 		standardCell.titleLabel?.isHidden = title == nil || title!.isEmpty

--- a/ThunderCloud/StandardGridItem.swift
+++ b/ThunderCloud/StandardGridItem.swift
@@ -20,9 +20,9 @@ open class StandardGridItem: GridItem {
         
         guard let standardCell = cell as? StandardGridItemCell else { return }
         
-        standardCell.imageView?.accessibilityLabel = imageAccessibilityLabel
+        standardCell.imageView?.accessibilityLabel = image?.accessibilityLabel
         standardCell.imageView?.isHidden = image == nil
-        standardCell.imageView?.image = image
+        standardCell.imageView?.image = image?.image
         standardCell.titleLabel?.isHidden = title == nil || title!.isEmpty
         standardCell.titleLabel?.text = title
         standardCell.subtitleLabel?.isHidden = description == nil || description!.isEmpty

--- a/ThunderCloud/StormImage.swift
+++ b/ThunderCloud/StormImage.swift
@@ -1,0 +1,19 @@
+//
+//  StormImage.swift
+//  ThunderCloud
+//
+//  Created by Simon Mitchell on 14/08/2019.
+//  Copyright © 2019 threesidedcube. All rights reserved.
+//
+
+import Foundation
+
+/// A structural representation of a storm `Image`, converted to UIKit UIImage and accessibility label
+public struct StormImage {
+    
+    /// The actual image which can be used when rendering content
+    public let image: UIImage
+    
+    /// An accessibility label which can be applied to `UIImageView` instances containing this image
+    public let accessibilityLabel: String?
+}

--- a/ThunderCloud/TabbedPageCollection.swift
+++ b/ThunderCloud/TabbedPageCollection.swift
@@ -59,7 +59,8 @@ open class TabbedPageCollection: UITabBarController, StormObjectProtocol, UITabB
                     return
                 }
                 
-                let tabImage = tabBarImage(with: StormGenerator.image(fromJSON: tabBarItemDict["image"]))
+                let tabStormImage = StormGenerator.image(fromJSON: tabBarItemDict["image"])
+                let tabImage = tabBarImage(with: tabStormImage?.image)
                 
                 if let title = tabBarItemDict["title"] as? [AnyHashable : Any] {
                     navTabController.title = StormLanguageController.shared.string(for: title)
@@ -67,9 +68,7 @@ open class TabbedPageCollection: UITabBarController, StormObjectProtocol, UITabB
                 
                 navTabController.tabBarItem.image = tabImage?.withRenderingMode(.alwaysOriginal)
                 navTabController.tabBarItem.selectedImage = tabImage
-                if let imageDict = tabBarItemDict["image"] as? [AnyHashable : Any], let accessibilityLabelDict = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
-                    navTabController.tabBarItem.accessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
-                }
+                navTabController.tabBarItem.accessibilityLabel = tabStormImage?.accessibilityLabel
                 
                 let navigationControllerClass = StormObjectFactory.shared.class(for: String(describing: UINavigationController.self)) as? UINavigationController.Type ?? UINavigationController.self
                 
@@ -92,14 +91,11 @@ open class TabbedPageCollection: UITabBarController, StormObjectProtocol, UITabB
                     viewController.tabBarItem.title = StormLanguageController.shared.string(for: title)
                 }
                 
-                let tabImage = tabBarImage(with: StormGenerator.image(fromJSON: tabBarItemDict["image"]))
+                let tabImage = StormGenerator.image(fromJSON: tabBarItemDict["image"])
                 
-                viewController.tabBarItem.image = tabImage?.withRenderingMode(.alwaysOriginal)
-                viewController.tabBarItem.selectedImage = tabImage
-                
-                if let imageDict = tabBarItemDict["image"] as? [AnyHashable : Any], let accessibilityLabelDict = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
-                    viewController.tabBarItem.accessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
-                }
+                viewController.tabBarItem.image = tabImage?.image.withRenderingMode(.alwaysOriginal)
+                viewController.tabBarItem.selectedImage = tabImage?.image
+                viewController.tabBarItem.accessibilityLabel = tabImage?.accessibilityLabel
                 
                 let navigationControllerClass = StormObjectFactory.shared.class(for: String(describing: UINavigationController.self)) as? UINavigationController.Type ?? UINavigationController.self
                 

--- a/ThunderCloud/TabbedPageCollection.swift
+++ b/ThunderCloud/TabbedPageCollection.swift
@@ -67,6 +67,9 @@ open class TabbedPageCollection: UITabBarController, StormObjectProtocol, UITabB
                 
                 navTabController.tabBarItem.image = tabImage?.withRenderingMode(.alwaysOriginal)
                 navTabController.tabBarItem.selectedImage = tabImage
+                if let imageDict = tabBarItemDict["image"] as? [AnyHashable : Any], let accessibilityLabelDict = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
+                    navTabController.tabBarItem.accessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
+                }
                 
                 let navigationControllerClass = StormObjectFactory.shared.class(for: String(describing: UINavigationController.self)) as? UINavigationController.Type ?? UINavigationController.self
                 
@@ -93,6 +96,10 @@ open class TabbedPageCollection: UITabBarController, StormObjectProtocol, UITabB
                 
                 viewController.tabBarItem.image = tabImage?.withRenderingMode(.alwaysOriginal)
                 viewController.tabBarItem.selectedImage = tabImage
+                
+                if let imageDict = tabBarItemDict["image"] as? [AnyHashable : Any], let accessibilityLabelDict = imageDict["accessibilityLabel"] as? [AnyHashable : Any] {
+                    viewController.tabBarItem.accessibilityLabel = StormLanguageController.shared.string(for: accessibilityLabelDict)
+                }
                 
                 let navigationControllerClass = StormObjectFactory.shared.class(for: String(describing: UINavigationController.self)) as? UINavigationController.Type ?? UINavigationController.self
                 

--- a/ThunderCloudTests/ListItemTests.swift
+++ b/ThunderCloudTests/ListItemTests.swift
@@ -166,21 +166,4 @@ class ListItemTests: XCTestCase {
         XCTAssert(listItem.embeddedLinks?[0].destination == "test1.example")
         XCTAssert(listItem.embeddedLinks?[1].destination == "test2.example")
     }
-
-    func test_init_withAccessibilityLabel_accessibilityLabelSet() {
-        
-        let dictionary: [AnyHashable : Any] = [
-            "class": "ListItemView",
-            "image": [
-                "accessibilityLabel": [
-                    "class": "Text",
-                    "content": "key1"
-                ]
-            ]
-        ]
-        
-        let listItem = ListItem(dictionary: dictionary, languageController: mockedLanguageController)
-        
-        XCTAssertEqual(listItem.imageAccessibilityLabel, "value1")
-    }
 }

--- a/ThunderCloudTests/ListItemTests.swift
+++ b/ThunderCloudTests/ListItemTests.swift
@@ -167,4 +167,20 @@ class ListItemTests: XCTestCase {
         XCTAssert(listItem.embeddedLinks?[1].destination == "test2.example")
     }
 
+    func test_init_withAccessibilityLabel_accessibilityLabelSet() {
+        
+        let dictionary: [AnyHashable : Any] = [
+            "class": "ListItemView",
+            "image": [
+                "accessibilityLabel": [
+                    "class": "Text",
+                    "content": "key1"
+                ]
+            ]
+        ]
+        
+        let listItem = ListItem(dictionary: dictionary, languageController: mockedLanguageController)
+        
+        XCTAssertEqual(listItem.imageAccessibilityLabel, "value1")
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds image accessibility labels to various storm classes and then forwards the label to the image views used in the UI.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/3sidedcube/ThunderCloud/issues/176

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The motivation behind this is to make the storm ecosystem ADA compliant!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A test has been added to `ListItem` to test that this is set when provided. Other places where this has been added should be tested, but @ryanbourneuk is currently working on a solution to dependency injection for tests so I will hold off on these for now!

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
