### PR TITLE
#190 - remove unneeded configure calls to remove duplicated buttons

### DIFF
--- a/ThunderCloud/ButtonListItem.swift
+++ b/ThunderCloud/ButtonListItem.swift
@@ -54,8 +54,6 @@ open class ButtonListItem: ListItem {
     /// - Parameter dictionary: A Storm object dictionary.
 	public required init(dictionary: [AnyHashable : Any]) {
 		super.init(dictionary: dictionary)
-		
-		configure(with: dictionary, languageController: StormLanguageController.shared)
 	}
     
     /// Given a Storm object dictionary, initialises a ButtonListItem.
@@ -65,9 +63,7 @@ open class ButtonListItem: ListItem {
     ///   - dictionary: A Storm object dictionary.
     ///   - languageController: A StormLanguageController instance. Defaults to `.shared`. Only override when running from unit tests - leave as `.shared` for production use.
     public override init(dictionary: [AnyHashable: Any], languageController: StormLanguageController = StormLanguageController.shared) {
-        super.init(dictionary: dictionary)
-        
-        configure(with: dictionary, languageController: languageController)
+        super.init(dictionary: dictionary, languageController: languageController)
     }
     
     /// When given a Storm object dictionary, and a StormLanguageController instance,

--- a/ThunderCloudTests/ButtonListItemTests.swift
+++ b/ThunderCloudTests/ButtonListItemTests.swift
@@ -95,6 +95,7 @@ class ButtonListItemTests: XCTestCase {
         
         let listItem = ButtonListItem(dictionary: dictionary, languageController: mockedLanguageController)
         
+        XCTAssert(listItem.embeddedLinks?.count == 1)
         XCTAssert(listItem.embeddedLinks?.first?.title == "value1")
         XCTAssert(listItem.embeddedLinks?.first?.destination == "test1.example")
         XCTAssert(listItem.title == "value2")
@@ -118,6 +119,7 @@ class ButtonListItemTests: XCTestCase {
         
         let listItem = ButtonListItem(dictionary: dictionary, languageController: mockedLanguageController)
         
+        XCTAssert(listItem.embeddedLinks?.count == 1)
         XCTAssert(listItem.embeddedLinks?.first?.title == "value1")
         XCTAssert(listItem.embeddedLinks?.first?.destination == "test1.example")
         XCTAssert(listItem.title == "value2")
@@ -148,6 +150,7 @@ class ButtonListItemTests: XCTestCase {
         
         let listItem = ButtonListItem(dictionary: dictionary, languageController: mockedLanguageController)
         
+        XCTAssert(listItem.embeddedLinks?.count == 2)
         XCTAssert(listItem.embeddedLinks?.first?.title == "value1")
         XCTAssert(listItem.embeddedLinks?.first?.destination == "test1.example")
         XCTAssert(listItem.embeddedLinks?[1].title == "value4")

--- a/ThunderCloudTests/ListItemTests.swift
+++ b/ThunderCloudTests/ListItemTests.swift
@@ -163,6 +163,7 @@ class ListItemTests: XCTestCase {
         XCTAssert(listItem.title == "value1")
         XCTAssert(listItem.subtitle == "value2")
         XCTAssert(listItem.link?.destination == "test3.example")
+        XCTAssert(listItem.embeddedLinks?.count == 2)
         XCTAssert(listItem.embeddedLinks?[0].destination == "test1.example")
         XCTAssert(listItem.embeddedLinks?[1].destination == "test2.example")
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Resolves #190, removing the duplicated buttons

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#190 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Buttons should not be duplicated for each link.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It has been run in the context of the affected app, and unit tests have been updated to ensure that the right amount of links are generated.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
