### PR TITLE
#203 - Fixes AppCollectionItem title

### DIFF
--- a/ThunderCloud/AppCollectionItem.swift
+++ b/ThunderCloud/AppCollectionItem.swift
@@ -11,16 +11,20 @@ import Foundation
 /// A model representation of an app to be shown in a `TSCAppScrollerItemViewCell`
 open class AppCollectionItem: StormObjectProtocol {
     
-    /// The app's icon
+    /// Defines the keys used to decode this data object.
+    enum DecoderKeys: String {
+        case icon
+        case identifier
+        case overlay
+    }
+    
+    /// The app's icon - derived from "icon"
     public let appIcon: StormImage?
     
-    /// The app's name
+    /// The app's name - derived from "overlay"
     public let appName: String?
     
-    /// The app's price
-    public let appPrice: String?
-    
-    /// The app identity for the app, contains information on the URL schemes, app name, iTunes id e.t.c.
+    /// The app identity for the app, contains information on the URL schemes, app name, iTunes id e.t.c. - derived from "identifier"
     public let app: AppIdentity?
     
     /// Initialises a new instance from a CMS representation of an app
@@ -28,28 +32,22 @@ open class AppCollectionItem: StormObjectProtocol {
     /// - Parameter dictionary: Dictionary to use to initialise and populate the app
     public required init(dictionary: [AnyHashable : Any]) {
         
-        let icon = StormGenerator.image(fromJSON: dictionary["icon"])
+        let icon = StormGenerator.image(fromJSON: dictionary[DecoderKeys.icon])
         appIcon = icon
         
         var appIdentifier: AppIdentity?
         
-        if let identifier = dictionary["identifier"] as? String {
+        if let identifier = dictionary[DecoderKeys.identifier] as? String {
             appIdentifier = AppLinkController().apps.first(where: {$0.identifier == identifier})
             app = appIdentifier
         } else {
             app = nil
         }
         
-        if let nameKey = dictionary["name"] as? String {
-            appName = StormLanguageController.shared.string(forKey: nameKey) ?? appIdentifier?.name
+        if let overlay = dictionary[DecoderKeys.overlay] as? [AnyHashable: Any] {
+            appName = StormLanguageController.shared.string(for: overlay) ?? appIdentifier?.name
         } else {
             appName = app?.name
-        }
-        
-        if let priceDictionary = dictionary["overlay"] as? [AnyHashable : Any] {
-            appPrice = StormLanguageController.shared.string(for: priceDictionary)
-        } else {
-            appPrice = nil
         }
     }
 }

--- a/ThunderCloud/AppCollectionItem.swift
+++ b/ThunderCloud/AppCollectionItem.swift
@@ -11,13 +11,6 @@ import Foundation
 /// A model representation of an app to be shown in a `TSCAppScrollerItemViewCell`
 open class AppCollectionItem: StormObjectProtocol {
     
-    /// Defines the keys used to decode this data object.
-    enum DecoderKeys: String {
-        case icon
-        case identifier
-        case overlay
-    }
-    
     /// The app's icon - derived from "icon"
     public let appIcon: StormImage?
     
@@ -32,19 +25,19 @@ open class AppCollectionItem: StormObjectProtocol {
     /// - Parameter dictionary: Dictionary to use to initialise and populate the app
     public required init(dictionary: [AnyHashable : Any]) {
         
-        let icon = StormGenerator.image(fromJSON: dictionary[DecoderKeys.icon])
+        let icon = StormGenerator.image(fromJSON: dictionary["icon"])
         appIcon = icon
         
         var appIdentifier: AppIdentity?
         
-        if let identifier = dictionary[DecoderKeys.identifier] as? String {
+        if let identifier = dictionary["identifier"] as? String {
             appIdentifier = AppLinkController().apps.first(where: {$0.identifier == identifier})
             app = appIdentifier
         } else {
             app = nil
         }
         
-        if let overlay = dictionary[DecoderKeys.overlay] as? [AnyHashable: Any] {
+        if let overlay = dictionary["overlay"] as? [AnyHashable: Any] {
             appName = StormLanguageController.shared.string(for: overlay) ?? appIdentifier?.name
         } else {
             appName = app?.name


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
AppCollectionItem was not displaying the title, as it was using `name` instead of `overlay`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Resolves #203 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In the ARC FA app, the AppCollectionCell object should be displaying a title. When the AppCollectionItem (which the cell depends on) was parsed it was attempting to read the non-existent `name` property, so the title would never show.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested in the context of the ARC FA project.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.