### PR TITLE
#215 - resolves an issue where streaming pages could not open web views

### DIFF
--- a/ThunderCloud.xcodeproj/project.pbxproj
+++ b/ThunderCloud.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		98224C1822FC2B6300D2BAE7 /* ButtonListItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98224C1722FC2B6300D2BAE7 /* ButtonListItemTests.swift */; };
 		98224C1922FC2BF500D2BAE7 /* StreamingPagesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C06C8D1DA5051100CEF0DD /* StreamingPagesTests.swift */; };
 		9863CED422D4DFA900E52D79 /* UIWindow+RightMostNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9863CED322D4DFA900E52D79 /* UIWindow+RightMostNavigationController.swift */; };
+		98C976D32330E44700C2E0E4 /* StreamingNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C976D22330E44700C2E0E4 /* StreamingNavigationController.swift */; };
 		98D3FC96231022330097B24F /* FirebaseAnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D3FC95231022330097B24F /* FirebaseAnalyticsTests.swift */; };
 		B104A4661FA7800800DDBB22 /* DummyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B104A4651FA7800800DDBB22 /* DummyViewController.swift */; };
 		B104A4681FA7815B00DDBB22 /* NavigationTabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B104A4671FA7815B00DDBB22 /* NavigationTabBarViewController.swift */; };
@@ -288,6 +289,7 @@
 		98224C1522FC1EAE00D2BAE7 /* ListItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListItemTests.swift; sourceTree = "<group>"; };
 		98224C1722FC2B6300D2BAE7 /* ButtonListItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonListItemTests.swift; sourceTree = "<group>"; };
 		9863CED322D4DFA900E52D79 /* UIWindow+RightMostNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindow+RightMostNavigationController.swift"; sourceTree = "<group>"; };
+		98C976D22330E44700C2E0E4 /* StreamingNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingNavigationController.swift; sourceTree = "<group>"; };
 		98D3FC95231022330097B24F /* FirebaseAnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseAnalyticsTests.swift; sourceTree = "<group>"; };
 		B104A4651FA7800800DDBB22 /* DummyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyViewController.swift; sourceTree = "<group>"; };
 		B104A4671FA7815B00DDBB22 /* NavigationTabBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationTabBarViewController.swift; sourceTree = "<group>"; };
@@ -751,6 +753,7 @@
 				B1226D851DE8A18800ED50CB /* TSCReachability.h */,
 				B1226D861DE8A18800ED50CB /* TSCReachability.m */,
 				B1E8C92D1DE314E3006C1A5C /* ExceptionCatcher.h */,
+				98C976D22330E44700C2E0E4 /* StreamingNavigationController.swift */,
 			);
 			name = "Content Controller";
 			sourceTree = "<group>";
@@ -1416,6 +1419,7 @@
 				B11266EA227C659400D68360 /* Storm.swift in Sources */,
 				B13778D620289644006FE6D5 /* QuizImageSelectionViewController.swift in Sources */,
 				B11EAF7A219B187000891792 /* LocalisationLocale.swift in Sources */,
+				98C976D32330E44700C2E0E4 /* StreamingNavigationController.swift in Sources */,
 				B10832281F0A9B04008B565D /* StormTableRow.swift in Sources */,
 				B19F00001FAB7A6800BA0523 /* LinkCollectionItem.swift in Sources */,
 				B13DE0E01F0D2E4300C6B9B7 /* TabBarMoreViewController.swift in Sources */,

--- a/ThunderCloud/NavigationController.swift
+++ b/ThunderCloud/NavigationController.swift
@@ -197,6 +197,12 @@ public extension UINavigationController {
             if let rightMostNavigationController = UIApplication.shared.keyWindow?.rightMostNavigationController {
                 navigationController = rightMostNavigationController
             }
+            
+            // But, if we're within the context of a streaming page, we should use a different navigation controller!
+            // This resolves an issue where the SFSafariViewController was being attempted to be opened outside of the visible navigation controller.
+            if let streamingPageNavigationController = UIApplication.shared.keyWindow?.rootViewController?.presentedViewController as? StreamingNavigationController {
+                navigationController = streamingPageNavigationController
+            }
 
             var url: URL?
 

--- a/ThunderCloud/StreamingNavigationController.swift
+++ b/ThunderCloud/StreamingNavigationController.swift
@@ -1,0 +1,17 @@
+//
+//  StreamingNavigationController.swift
+//  ThunderCloud
+//
+//  Created by Ryan Bourne on 17/09/2019.
+//  Copyright © 2019 threesidedcube. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+/// An override of UINavigationController, that is used whenever we present a Streaming Page within the app.
+/// We can check if the presentedViewController is a StreamingNavigationController at run time and if it is, we know that there's a streaming page presented.
+/// We can then switch to present web views within this navigation controller.
+public class StreamingNavigationController: UINavigationController {
+    
+}

--- a/ThunderCloud/TSCAppDelegate.swift
+++ b/ThunderCloud/TSCAppDelegate.swift
@@ -121,7 +121,7 @@ open class TSCAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificatio
 					guard let viewController = stormViewController else { return }
 					
 					viewController.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(self.dismissStreamedPage))
-					let navController = UINavigationController(rootViewController: viewController)
+					let navController = StreamingNavigationController(rootViewController: viewController)
 					window.rootViewController?.present(navController, animated: true, completion: nil)
 				}
 			})
@@ -138,7 +138,7 @@ open class TSCAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificatio
 			guard let viewController = StormGenerator.viewController(URL: pageURL) else { return false }
 			
 			viewController.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: viewController, action: #selector(UIViewController.dismissAnimated))
-			let navController = UINavigationController(rootViewController: viewController)
+			let navController = StreamingNavigationController(rootViewController: viewController)
 			window?.rootViewController?.present(navController, animated: true, completion: nil)
 			
 			return true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR contains a fix, that allows streaming pages to open web views in the correct place in the navigation hierarchy.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Resolves #215 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This fix allows streaming pages to open web views, instead of clients having to set every link to open externally.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested in the context of the affected apps.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
