### PR TITLE
#217 - Fixes AppLink not responding

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 github "3sidedcube/ThunderTable" == 1.2.1
 github "3sidedcube/ThunderCollection" == 1.1
 github "3sidedcube/ThunderBasics" == 1.2.2
-github "3sidedcube/ThunderRequest" == 2.0.3
+github "3sidedcube/ThunderRequest" == 2.0.4

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "3sidedcube/ThunderBasics" "v1.2.2"
 github "3sidedcube/ThunderCollection" "v1.1"
-github "3sidedcube/ThunderRequest" "v2.0.3"
+github "3sidedcube/ThunderRequest" "v2.0.4"
 github "3sidedcube/ThunderTable" "v1.2.1"

--- a/ThunderCloud/DeveloperModeTheme.swift
+++ b/ThunderCloud/DeveloperModeTheme.swift
@@ -11,11 +11,18 @@ import ThunderTable
 
 /// This theme is applied when the app switches to Dev mode, turning the app a vibrant green colour
 class DeveloperModeTheme: Theme {
-	
-	override init() {
-		
-		super.init()
-		mainColor = UIColor(red: 138/255.0, green: 207/255, blue: 25/255, alpha: 1)
-		titleTextColor = .white
-	}
+    
+    override var mainColor: UIColor {
+        get {
+            return UIColor(red: 138/255.0, green: 207/255, blue: 25/255, alpha: 1)
+        }
+        set { }
+    }
+    
+    override var titleTextColor: UIColor {
+        get {
+            return .white
+        }
+        set { }
+    }
 }

--- a/ThunderCloud/StormLanguageController.swift
+++ b/ThunderCloud/StormLanguageController.swift
@@ -473,7 +473,7 @@ open class StormLanguageController: NSObject {
     ///
     /// - Parameter key: The key for which a localised string should be returned.
     /// - Returns: Returns the localised string for the required key.
-    public func string(forKey key: String) -> String? {
+    open func string(forKey key: String) -> String? {
         return string(forKey: key, withFallback: key)
     }
     
@@ -483,7 +483,7 @@ open class StormLanguageController: NSObject {
     ///   - key: The key for which a localised string should be returned.
     ///   - fallbackString: The fallback string to be used if the string doesn't exist in the key-value pair dictionary.
     /// - Returns: A string of either the localisation or the fallback string
-    public func string(forKey key: String, withFallback fallbackString: String?) -> String? {
+    open func string(forKey key: String, withFallback fallbackString: String?) -> String? {
         
         guard let languageDictionary = languageDictionary, var string = languageDictionary[key] as? String else {
             return fallbackString

--- a/ThunderCloud/StormLink.swift
+++ b/ThunderCloud/StormLink.swift
@@ -45,6 +45,7 @@ open class StormLink: NSObject, StormObjectProtocol {
         configure(with: dictionary, languageController: StormLanguageController.shared)
         
         guard url != nil
+            || linkClass == .app
             || linkClass == .sms
             || linkClass == .emergency
             || linkClass == .share
@@ -65,6 +66,7 @@ open class StormLink: NSObject, StormObjectProtocol {
         configure(with: dictionary, languageController: languageController)
         
         guard url != nil
+            || linkClass == .app
             || linkClass == .sms
             || linkClass == .emergency
             || linkClass == .share

--- a/ThunderCloudTests/StormLinkTests.swift
+++ b/ThunderCloudTests/StormLinkTests.swift
@@ -137,3 +137,19 @@ class StormLinkTests: XCTestCase {
         }
     }
 }
+
+extension StormLinkTests {
+    
+    func test_AppLink_initialisesCorrectly() {
+        let linkDictionary: [String: Any] = [
+            "class": "AppLink",
+            "destination": "",
+            "identifier": "BRC_STORM-1-2",
+            "title": [ "class": "Text", "content": "245l" ]
+        ]
+        
+        let stormLink = StormLink(dictionary: linkDictionary)
+        
+        XCTAssert(stormLink?.linkClass == .app)
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes an issue, where any `AppLink`s were being destroyed on init as they did not have a URL.

**Note:** This will need to be released in v1.4.2, and also in a v1.5.2 release - so we can cover pre & post ADA change versions

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Resolves #217 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required as Storm apps can make use of `AppLink`s to load / allow for downloading relevant apps.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested in the context of the affected app.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.