### PR TITLE
Declares `StormImage` initialiser public so can be used in projects

### DIFF
--- a/ThunderCloud/StormImage.swift
+++ b/ThunderCloud/StormImage.swift
@@ -16,4 +16,12 @@ public struct StormImage {
     
     /// An accessibility label which can be applied to `UIImageView` instances containing this image
     public let accessibilityLabel: String?
+    
+    /// Allocates a new image with the given `UIImage` and accessibility text
+    /// - Parameter image: The image this storm image represents
+    /// - Parameter accessibilityLabel: An accessibility label describing the image
+    public init(image: UIImage, accessibilityLabel: String?) {
+        self.image = image
+        self.accessibilityLabel = accessibilityLabel
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updates `StormImage` initialiser to be public so it can be called by users of the framework

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
GDPC First Aid uses `StormImage` externally to the framework.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Project compiles, no need for testing other than that.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
