### PR TITLE
Updates `NavigationBarDataSource` to make use of new iOS 13 styling

### DIFF
--- a/ThunderCloud/NavigationController.swift
+++ b/ThunderCloud/NavigationController.swift
@@ -16,21 +16,38 @@ import AVKit
 /// Any `UIViewController` can comply to this delegate. The extension provided in this file uses this method to style the navigation bar
 public protocol NavigationBarDataSource {
     
+    @available(iOS, deprecated: 13.0, obsoleted: 14.0, message: "Please use `UINavigationBarAppearance` variables instead")
     var navigationBarBackgroundImage: UIImage? { get }
     
+    @available(iOS, deprecated: 13.0, obsoleted: 14.0, message: "Please use `UINavigationBarAppearance` variables instead")
     var navigationBarShadowImage: UIImage? { get }
     
+    @available(iOS, deprecated: 13.0, obsoleted: 14.0, message: "Please use `UINavigationBarAppearance` variables instead")
     var navigationBarIsTranslucent: Bool { get }
     
+    @available(iOS, deprecated: 13.0, obsoleted: 14.0, message: "Please use `UINavigationBarAppearance` variables instead")
     var navigationBarIsOpaque: Bool { get }
     
+    @available(iOS, deprecated: 13.0, obsoleted: 14.0, message: "Please use `UINavigationBarAppearance` variables instead")
     var navigationBarAlpha: CGFloat { get }
     
+    @available(iOS, deprecated: 13.0, obsoleted: 14.0, message: "Please use `UINavigationBarAppearance` variables instead")
     var navigationBarTintColor: UIColor? { get }
     
+    @available(iOS, deprecated: 13.0, obsoleted: 14.0, message: "Please use `UINavigationBarAppearance` variables instead")
     var navigationBarBackgroundColor: UIColor? { get }
     
+    @available(iOS, deprecated: 13.0, obsoleted: 14.0, message: "Please use `UINavigationBarAppearance` variables instead")
     var navigationBarTitleTextAttributes: [NSAttributedString.Key : Any]? { get }
+    
+    @available(iOS 13.0, *)
+    var standardAppearance: UINavigationBarAppearance { get }
+    
+    @available(iOS 13.0, *)
+    var compactAppearance: UINavigationBarAppearance { get }
+    
+    @available(iOS 13.0, *)
+    var scrollEdgeAppearance: UINavigationBarAppearance { get }
 }
 
 public extension NavigationBarDataSource {
@@ -65,6 +82,57 @@ public extension NavigationBarDataSource {
     
     var navigationBarTitleTextAttributes: [NSAttributedString.Key : Any]? {
         return nil
+    }
+    
+    @available(iOS 13.0, *)
+    var standardAppearance: UINavigationBarAppearance {
+        
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithDefaultBackground()
+        appearance.backgroundColor = ThemeManager.shared.theme.navigationBarBackgroundColor
+        
+        let button = UIBarButtonItemAppearance(style: .plain)
+        button.normal.titleTextAttributes = [.foregroundColor: ThemeManager.shared.theme.navigationBarTintColor]
+        appearance.buttonAppearance = button
+        
+        appearance.titleTextAttributes = [.foregroundColor: ThemeManager.shared.theme.navigationBarTintColor]
+        appearance.largeTitleTextAttributes = [.foregroundColor: ThemeManager.shared.theme.navigationBarTintColor]
+        
+        return appearance
+    }
+    
+    @available(iOS 13.0, *)
+    var compactAppearance: UINavigationBarAppearance {
+        
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithDefaultBackground()
+        appearance.backgroundColor = ThemeManager.shared.theme.navigationBarBackgroundColor
+        
+        let button = UIBarButtonItemAppearance(style: .plain)
+        button.normal.titleTextAttributes = [.foregroundColor: ThemeManager.shared.theme.navigationBarTintColor]
+        appearance.buttonAppearance = button
+        
+        appearance.titleTextAttributes = [.foregroundColor: ThemeManager.shared.theme.navigationBarTintColor]
+        appearance.largeTitleTextAttributes = [.foregroundColor: ThemeManager.shared.theme.navigationBarTintColor]
+        
+        return appearance
+    }
+    
+    @available(iOS 13.0, *)
+    var scrollEdgeAppearance: UINavigationBarAppearance {
+        
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithDefaultBackground()
+        appearance.backgroundColor = ThemeManager.shared.theme.navigationBarBackgroundColor
+        
+        let button = UIBarButtonItemAppearance(style: .plain)
+        button.normal.titleTextAttributes = [.foregroundColor: ThemeManager.shared.theme.navigationBarTintColor]
+        appearance.buttonAppearance = button
+        
+        appearance.titleTextAttributes = [.foregroundColor: ThemeManager.shared.theme.navigationBarTintColor]
+        appearance.largeTitleTextAttributes = [.foregroundColor: ThemeManager.shared.theme.navigationBarTintColor]
+        
+        return appearance
     }
 }
 
@@ -550,24 +618,36 @@ public extension UINavigationController {
         
         let defaultNavigationBar = UINavigationBar.appearance()
         
-        let backgroundImage = navigationBarDataSource.navigationBarBackgroundImage ?? defaultNavigationBar.backgroundImage(for: .default)
-        let shadowImage = navigationBarDataSource.navigationBarShadowImage ?? defaultNavigationBar.shadowImage
-        let isTranslucent = navigationBarDataSource.navigationBarIsTranslucent
-        let tintColor = navigationBarDataSource.navigationBarTintColor
-        let backgroundColor = navigationBarDataSource.navigationBarBackgroundColor
-        let titleAttributes = navigationBarDataSource.navigationBarTitleTextAttributes
-        let isOpaque = navigationBarDataSource.navigationBarIsOpaque
-        
-        UIView.animate(withDuration: duration) { [weak self] in
+        if #available(iOS 13.0, *) {
             
-            self?.navigationBar.subviews.first?.alpha = navigationBarDataSource.navigationBarAlpha
-            self?.navigationBar.setBackgroundImage(backgroundImage, for: .default)
-            self?.navigationBar.shadowImage = shadowImage
-            self?.navigationBar.isTranslucent = isTranslucent
-            self?.navigationBar.isOpaque = isOpaque
-            self?.navigationBar.tintColor = tintColor
-            self?.navigationBar.barTintColor = backgroundColor
-            self?.navigationBar.titleTextAttributes = titleAttributes
+            UIView.animate(withDuration: duration) { [weak self] in
+                
+                self?.navigationBar.standardAppearance = navigationBarDataSource.standardAppearance
+                self?.navigationBar.scrollEdgeAppearance = navigationBarDataSource.scrollEdgeAppearance
+                self?.navigationBar.compactAppearance = navigationBarDataSource.compactAppearance
+            }
+            
+        } else {
+            
+            let backgroundImage = navigationBarDataSource.navigationBarBackgroundImage ?? defaultNavigationBar.backgroundImage(for: .default)
+            let shadowImage = navigationBarDataSource.navigationBarShadowImage ?? defaultNavigationBar.shadowImage
+            let isTranslucent = navigationBarDataSource.navigationBarIsTranslucent
+            let tintColor = navigationBarDataSource.navigationBarTintColor
+            let backgroundColor = navigationBarDataSource.navigationBarBackgroundColor
+            let titleAttributes = navigationBarDataSource.navigationBarTitleTextAttributes
+            let isOpaque = navigationBarDataSource.navigationBarIsOpaque
+            
+            UIView.animate(withDuration: duration) { [weak self] in
+                
+                self?.navigationBar.subviews.first?.alpha = navigationBarDataSource.navigationBarAlpha
+                self?.navigationBar.setBackgroundImage(backgroundImage, for: .default)
+                self?.navigationBar.shadowImage = shadowImage
+                self?.navigationBar.isTranslucent = isTranslucent
+                self?.navigationBar.isOpaque = isOpaque
+                self?.navigationBar.tintColor = tintColor
+                self?.navigationBar.barTintColor = backgroundColor
+                self?.navigationBar.titleTextAttributes = titleAttributes
+            }
         }
     }
     

--- a/ThunderCloud/NavigationController.swift
+++ b/ThunderCloud/NavigationController.swift
@@ -41,13 +41,13 @@ public protocol NavigationBarDataSource {
     var navigationBarTitleTextAttributes: [NSAttributedString.Key : Any]? { get }
     
     @available(iOS 13.0, *)
-    var standardAppearance: UINavigationBarAppearance { get }
+    var navigationBarStandardAppearance: UINavigationBarAppearance { get }
     
     @available(iOS 13.0, *)
-    var compactAppearance: UINavigationBarAppearance { get }
+    var navigationBarCompactAppearance: UINavigationBarAppearance { get }
     
     @available(iOS 13.0, *)
-    var scrollEdgeAppearance: UINavigationBarAppearance { get }
+    var navigationBarScrollEdgeAppearance: UINavigationBarAppearance { get }
 }
 
 public extension NavigationBarDataSource {
@@ -85,7 +85,7 @@ public extension NavigationBarDataSource {
     }
     
     @available(iOS 13.0, *)
-    var standardAppearance: UINavigationBarAppearance {
+    var navigationBarStandardAppearance: UINavigationBarAppearance {
         
         let appearance = UINavigationBarAppearance()
         appearance.configureWithDefaultBackground()
@@ -102,7 +102,7 @@ public extension NavigationBarDataSource {
     }
     
     @available(iOS 13.0, *)
-    var compactAppearance: UINavigationBarAppearance {
+    var navigationBarCompactAppearance: UINavigationBarAppearance {
         
         let appearance = UINavigationBarAppearance()
         appearance.configureWithDefaultBackground()
@@ -119,7 +119,7 @@ public extension NavigationBarDataSource {
     }
     
     @available(iOS 13.0, *)
-    var scrollEdgeAppearance: UINavigationBarAppearance {
+    var navigationBarScrollEdgeAppearance: UINavigationBarAppearance {
         
         let appearance = UINavigationBarAppearance()
         appearance.configureWithDefaultBackground()
@@ -622,9 +622,9 @@ public extension UINavigationController {
             
             UIView.animate(withDuration: duration) { [weak self] in
                 
-                self?.navigationBar.standardAppearance = navigationBarDataSource.standardAppearance
-                self?.navigationBar.scrollEdgeAppearance = navigationBarDataSource.scrollEdgeAppearance
-                self?.navigationBar.compactAppearance = navigationBarDataSource.compactAppearance
+                self?.navigationBar.standardAppearance = navigationBarDataSource.navigationBarStandardAppearance
+                self?.navigationBar.scrollEdgeAppearance = navigationBarDataSource.navigationBarScrollEdgeAppearance
+                self?.navigationBar.compactAppearance = navigationBarDataSource.navigationBarCompactAppearance
             }
             
         } else {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Deprecates old styling of navigation based on properties and adds new protocol variables for `UINavigationBarAppearance` based styling

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The old protocol properties don't override navigation bars styled using the new method when applied to `UINavigationBar.appearance()` so we need to use this to override custom styling on particular screens!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Has been tested by using this branch locally in GDPC Hazards

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
