### PR TITLE
Updates QuizProgressListItemView to lazy init available quizzes

### DIFF
--- a/ThunderCloud.xcodeproj/project.pbxproj
+++ b/ThunderCloud.xcodeproj/project.pbxproj
@@ -132,7 +132,6 @@
 		B139044B1F8D174300B52DCF /* NavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B139044A1F8D174300B52DCF /* NavigationController.swift */; };
 		B13DE0C01F0CFE2500C6B9B7 /* ImageListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B13DE0BF1F0CFE2500C6B9B7 /* ImageListItem.swift */; };
 		B13DE0C61F0CFFDD00C6B9B7 /* AnimatedImageListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B13DE0C51F0CFFDD00C6B9B7 /* AnimatedImageListItem.swift */; };
-		B13DE0C81F0D126C00C6B9B7 /* QuizProgressListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B13DE0C71F0D126C00C6B9B7 /* QuizProgressListItemView.swift */; };
 		B13DE0CA1F0D145B00C6B9B7 /* VideoListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B13DE0C91F0D145B00C6B9B7 /* VideoListItemView.swift */; };
 		B13DE0CC1F0D154D00C6B9B7 /* VideoListItemViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B13DE0CB1F0D154D00C6B9B7 /* VideoListItemViewCell.swift */; };
 		B13DE0CE1F0D157200C6B9B7 /* VideoListItemViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B13DE0CD1F0D157200C6B9B7 /* VideoListItemViewCell.xib */; };
@@ -212,6 +211,7 @@
 		B1E029CC1FA3343A007D1613 /* AccordionTabBarItemTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1E029CA1FA3343A007D1613 /* AccordionTabBarItemTableViewCell.swift */; };
 		B1E029CD1FA3343A007D1613 /* AccordionTabBarItemTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B1E029CB1FA3343A007D1613 /* AccordionTabBarItemTableViewCell.xib */; };
 		B1E088861DA68DCC00E45E47 /* ContentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1E088851DA68DCC00E45E47 /* ContentController.swift */; };
+		B1E3A8652362EC8E009E1CDE /* QuizProgressListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1E3A8642362EC8D009E1CDE /* QuizProgressListItemView.swift */; };
 		B1E49A2F229FD4D3006F72B8 /* ThunderBasics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B190A89E228EB19C00E44821 /* ThunderBasics.framework */; };
 		B1E49A30229FD4D6006F72B8 /* ThunderCollection.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B190A8A1228EB19C00E44821 /* ThunderCollection.framework */; };
 		B1E49A31229FD4D9006F72B8 /* ThunderRequest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B190A8A0228EB19C00E44821 /* ThunderRequest.framework */; };
@@ -394,7 +394,6 @@
 		B139044A1F8D174300B52DCF /* NavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationController.swift; sourceTree = "<group>"; };
 		B13DE0BF1F0CFE2500C6B9B7 /* ImageListItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageListItem.swift; sourceTree = "<group>"; };
 		B13DE0C51F0CFFDD00C6B9B7 /* AnimatedImageListItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimatedImageListItem.swift; sourceTree = "<group>"; };
-		B13DE0C71F0D126C00C6B9B7 /* QuizProgressListItemView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuizProgressListItemView.swift; sourceTree = "<group>"; };
 		B13DE0C91F0D145B00C6B9B7 /* VideoListItemView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoListItemView.swift; sourceTree = "<group>"; };
 		B13DE0CB1F0D154D00C6B9B7 /* VideoListItemViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoListItemViewCell.swift; sourceTree = "<group>"; };
 		B13DE0CD1F0D157200C6B9B7 /* VideoListItemViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = VideoListItemViewCell.xib; sourceTree = "<group>"; };
@@ -472,6 +471,7 @@
 		B1E029CA1FA3343A007D1613 /* AccordionTabBarItemTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccordionTabBarItemTableViewCell.swift; sourceTree = "<group>"; };
 		B1E029CB1FA3343A007D1613 /* AccordionTabBarItemTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AccordionTabBarItemTableViewCell.xib; sourceTree = "<group>"; };
 		B1E088851DA68DCC00E45E47 /* ContentController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentController.swift; sourceTree = "<group>"; };
+		B1E3A8642362EC8D009E1CDE /* QuizProgressListItemView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuizProgressListItemView.swift; sourceTree = "<group>"; };
 		B1E8C92D1DE314E3006C1A5C /* ExceptionCatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExceptionCatcher.h; sourceTree = "<group>"; };
 		B1E8C9381DE33144006C1A5C /* DeveloperMode.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = DeveloperMode.storyboard; sourceTree = "<group>"; };
 		B1E8C93A1DE33200006C1A5C /* DownloadingStormBundleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownloadingStormBundleViewController.swift; sourceTree = "<group>"; };
@@ -565,9 +565,9 @@
 				B137791C2028C243006FE6D5 /* View Controllers */,
 				3682CDEB19F65B3B00E354A6 /* Questions */,
 				B11266E5227C626700D68360 /* QuizBadgeScrollerCollectionViewCell.swift */,
+				B1E3A8642362EC8D009E1CDE /* QuizProgressListItemView.swift */,
 				B10832601F0BD372008B565D /* QuizBadgeShowcase.swift */,
 				B10832231F0A8E8A008B565D /* QuizCompletionViewController.swift */,
-				B13DE0C71F0D126C00C6B9B7 /* QuizProgressListItemView.swift */,
 				B13DE11D1F0D3D5500C6B9B7 /* ProgressListItemCell.swift */,
 				B13DE11B1F0D3D2700C6B9B7 /* ProgressListItemCell.xib */,
 			);
@@ -1299,6 +1299,7 @@
 				B1163E791F0CF27400A9E8E2 /* UnorderedListItemCell.swift in Sources */,
 				B179EC221F0F8E980007ED3F /* LocalisationEditViewController.swift in Sources */,
 				B10832791F0BD547008B565D /* CustomUploadListItemView.swift in Sources */,
+				B1E3A8652362EC8E009E1CDE /* QuizProgressListItemView.swift in Sources */,
 				B151030B1FAB48BE0044A4AC /* PlaceholderViewController.swift in Sources */,
 				B179EC2E1F0FA4740007ED3F /* DeveloperModeTheme.swift in Sources */,
 				B10832671F0BD424008B565D /* ChunkyListItemView.swift in Sources */,
@@ -1372,7 +1373,6 @@
 				49F12CA91E4370C700EC2321 /* StormGenerator.swift in Sources */,
 				B108327D1F0BD594008B565D /* ButtonListItemView.swift in Sources */,
 				B1163E731F0CEE3400A9E8E2 /* ToggleableListItemCell.swift in Sources */,
-				B13DE0C81F0D126C00C6B9B7 /* QuizProgressListItemView.swift in Sources */,
 				B1B0469B1F0E827900FD2FA7 /* EditLocalisationRow.swift in Sources */,
 				B151032F1FAB5B420044A4AC /* AppCollectionItem.swift in Sources */,
 				B13DE1221F0E2A3100C6B9B7 /* ListPage.swift in Sources */,

--- a/ThunderCloud/List.swift
+++ b/ThunderCloud/List.swift
@@ -23,9 +23,15 @@ open class List: StormObject, Section {
 	
 	/// The table section's footer
 	open var footer: String?
-	
-	/// The table section's rows
-	open var rows: [Row] = []
+    
+    /// The table section's rows
+    open lazy var rows: [Row] = {
+        return children?.compactMap({ (child) -> Row? in
+            return StormObjectFactory.shared.stormObject(with: child) as? Row
+        }) ?? []
+    }()
+    
+    private var children: [[AnyHashable : Any]]?
 	
 	required public init(dictionary: [AnyHashable : Any]) {
 		
@@ -37,12 +43,7 @@ open class List: StormObject, Section {
 			footer = StormLanguageController.shared.string(for: footerDict)
 		}
 		
-		if let children = dictionary["children"] as? [[AnyHashable : Any]] {
-			
-			rows = children.compactMap({ (child) -> Row? in
-				return StormObjectFactory.shared.stormObject(with: child) as? Row
-			})
-		}
+        children = dictionary["children"] as? [[AnyHashable : Any]]
 		
 		super.init(dictionary: dictionary)
 	}

--- a/ThunderCloud/List.swift
+++ b/ThunderCloud/List.swift
@@ -9,6 +9,28 @@
 import UIKit
 import ThunderTable
 
+class IndexableGroupView: StormObject, Section {
+    
+    var editHandler: EditHandler?
+    
+    var selectionHandler: SelectionHandler?
+    
+    /// The table section's rows
+    open lazy var rows: [Row] = {
+        return children?.compactMap({ (child) -> Row? in
+            return StormObjectFactory.shared.indexableStormObject(with: child) as? Row
+        }) ?? []
+    }()
+    
+    private var children: [[AnyHashable : Any]]?
+    
+    required public init(dictionary: [AnyHashable : Any]) {
+        
+        children = dictionary["children"] as? [[AnyHashable : Any]]
+        super.init(dictionary: dictionary)
+    }
+}
+
 /// `List` is a `StormObject` that represents a `TableSection` and conforms to `Section`. Each section in a storm generated table view will be represented as a `List`
 open class List: StormObject, Section {
     

--- a/ThunderCloud/ListPage.swift
+++ b/ThunderCloud/ListPage.swift
@@ -133,7 +133,7 @@ open class IndexableListPage: CoreSpotlightIndexable, StormObjectProtocol {
         
         guard let children = dictionary["children"] as? [[AnyHashable : Any]] else { return nil }
         let sections = children.compactMap { (child) -> Section? in
-            return StormObjectFactory.shared.stormObject(with: child) as? Section
+            return StormObjectFactory.shared.indexableStormObject(with: child) as? Section
         }
         
         guard !sections.isEmpty else { return nil }

--- a/ThunderCloud/QuizCompletionViewController.swift
+++ b/ThunderCloud/QuizCompletionViewController.swift
@@ -9,7 +9,6 @@
 import UIKit
 import ThunderTable
 
-public let OPEN_NEXT_QUIZ_NOTIFICATION = NSNotification.Name.init("OPEN_NEXT_QUIZ_NOTIFICATION")
 public let QUIZ_COMPLETED_NOTIFICATION = NSNotification.Name.init("QUIZ_COMPLETED_NOTIFICATION")
 
 extension Quiz {

--- a/ThunderCloud/QuizProgressListItemView.swift
+++ b/ThunderCloud/QuizProgressListItemView.swift
@@ -9,6 +9,13 @@
 import UIKit
 import ThunderTable
 
+class IndexableQuizProgressListItemView: StormObjectProtocol {
+    
+    required init?(dictionary: [AnyHashable : Any]) {
+        
+    }
+}
+
 /// A table row which displays a user's progress through a set of quizzes and upon selection enters the next incomplete quiz in the set
 open class QuizProgressListItemView: ListItem {
     

--- a/ThunderCloud/QuizProgressListItemView.swift
+++ b/ThunderCloud/QuizProgressListItemView.swift
@@ -58,17 +58,12 @@ open class QuizProgressListItemView: ListItem {
             return !BadgeController.shared.hasEarntBadge(with: badgeId)
         })
     }
-    
-    private var nextQuizObserver: NSObjectProtocol?
-    
+        
     private var quizCompletedObserver: NSObjectProtocol?
     
     private var badgesClearedObserver: NSObjectProtocol?
     
     deinit {
-        if let nextQuizObserver = nextQuizObserver {
-            NotificationCenter.default.removeObserver(nextQuizObserver)
-        }
         if let quizCompletedObserver = quizCompletedObserver {
             NotificationCenter.default.removeObserver(quizCompletedObserver)
         }

--- a/ThunderCloud/QuizProgressListItemView.swift
+++ b/ThunderCloud/QuizProgressListItemView.swift
@@ -90,11 +90,6 @@ open class QuizProgressListItemView: ListItem {
         }
          
         self.quizUrls = quizURLs
-                        
-        // This is obsolete for the moment as this notification isn't sent by anywhere
-        nextQuizObserver = NotificationCenter.default.addObserver(forName: OPEN_NEXT_QUIZ_NOTIFICATION, object: nil, queue: .main, using: { [weak self] (notification) in
-            self?.showNextQuiz(with: notification.object as? String)
-        })
         
         quizCompletedObserver = NotificationCenter.default.addObserver(forName: QUIZ_COMPLETED_NOTIFICATION, object: nil, queue: .main, using: { [weak self] (notification) in
             self?.reloadData()

--- a/ThunderCloud/QuizProgressListItemView.swift
+++ b/ThunderCloud/QuizProgressListItemView.swift
@@ -13,8 +13,8 @@ import ThunderTable
 open class QuizProgressListItemView: ListItem {
     
     /// An array of quizzes available to the user
-    public lazy var availableQuizzes: [Quiz]? = {
-        quizUrls?.compactMap({ (quizURL) -> Quiz? in
+    public lazy var availableQuizzes: [Quiz]? = { [unowned self] in
+        return self.quizUrls?.compactMap({ (quizURL) -> Quiz? in
             guard let pagePath = URL(string: quizURL) else {
                 return nil
             }

--- a/ThunderCloud/StormObject.swift
+++ b/ThunderCloud/StormObject.swift
@@ -157,14 +157,11 @@ public class StormObjectFactory: NSObject {
             className = listItemName
         }
         
-        // List page will always need to be allocated on a main thread, so we'll create a proxy object
-        // which can be overriden.
-        if className == "ListPage" {
-            className = "IndexableListPage"
+        // First try and create a class `Indexable+className` so we can avoid threading issues where we deem necessary
+        var _stormClass: AnyClass? = self.class(for: "Indexable"+className)
+        if _stormClass == nil {
+            _stormClass = self.class(for: className)
         }
-        
-        // We need to prefix class name with ThunderCloud. as classes are namespaced in swift
-        let _stormClass: AnyClass? = self.class(for: className)
         
         guard let stormClass = _stormClass else {
             print("[Storm Factory] Warning - missing storm object for indexable class: \(className)")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This makes the init method safe to call on background threads so CoreSpotlightIndexing doesn't crash when it gets to this item!

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
ARC First Aid was crashing when core spotlight indexing occurred

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Has been tested locally in the affected app.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
