### PR TITLE
Fixes quiz restart on iPad

### DIFF
--- a/ThunderCloud/QuizQuestionContainerViewController.swift
+++ b/ThunderCloud/QuizQuestionContainerViewController.swift
@@ -391,7 +391,7 @@ open class QuizQuestionContainerViewController: AccessibilityRefreshingViewContr
             
             // Set view controllers rather than popping otherwise first VC doesn't reset and we end up answering
             // the first question twice!
-            navigationController?.setViewControllers([quiz?.questionViewController()].compactMap({ $0 }), animated: true)
+            navigationController?.setViewControllers([quiz?.questionViewController()].compactMap({ $0 }), animated: false)
         }
     }
     

--- a/ThunderCloud/QuizQuestionContainerViewController.swift
+++ b/ThunderCloud/QuizQuestionContainerViewController.swift
@@ -389,7 +389,9 @@ open class QuizQuestionContainerViewController: AccessibilityRefreshingViewContr
                 return
             }
             
-            navigationController?.popToRootViewController(animated: true)
+            // Set view controllers rather than popping otherwise first VC doesn't reset and we end up answering
+            // the first question twice!
+            navigationController?.setViewControllers([quiz?.questionViewController()].compactMap({ $0 }), animated: true)
         }
     }
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replaces navigation stack when restarting quiz on iPad rather than popping

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#234 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes a bug on quizzes when using on iPad

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by using this commit in Cartfile

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
