### PR TITLE
Fixes quiz completion dynamic fonts

### DIFF
--- a/ThunderCloud/LegacySpotlightListItemCell.swift
+++ b/ThunderCloud/LegacySpotlightListItemCell.swift
@@ -155,7 +155,7 @@ open class LegacySpotlightListItemCell: StormTableViewCell {
         spotlightCell.titleLabel.shadowColor = UIColor.black.withAlphaComponent(0.5)
         spotlightCell.titleLabel.shadowOffset = CGSize(width: 0, height: 1)
         
-        spotlightCell.textShadowImageView.isHidden = spotlightCell.titleLabel.text == nil || spotlightCell.titleLabel.text!.isEmpty
+        spotlightCell.textShadowImageView.isHidden = spotlightCell.titleLabel.text?.isEmpty ?? true
     }
 }
 

--- a/ThunderCloud/ListItem.swift
+++ b/ThunderCloud/ListItem.swift
@@ -172,7 +172,7 @@ open class ListItem: StormObject, Row {
                 stormCell.mainStackView?.spacing = 0
             }
             
-            stormCell.contentStackView?.isHidden = (title == nil || title!.isEmpty) && (subtitle == nil || subtitle!.isEmpty) && image == nil && imageURL == nil
+            stormCell.contentStackView?.isHidden = (title?.isEmpty ?? true) && (subtitle?.isEmpty ?? true) && image == nil && imageURL == nil
         }
         
         if let titleTextColor = titleTextColor {
@@ -190,8 +190,9 @@ open class ListItem: StormObject, Row {
         }
         
         if let tableCell = cell as? TableViewCell {
-            tableCell.cellTextLabel?.isHidden = title == nil || title!.isEmpty
-            tableCell.cellDetailLabel?.isHidden = subtitle == nil || subtitle!.isEmpty
+            
+            tableCell.cellTextLabel?.isHidden = title?.isEmpty ?? true
+            tableCell.cellDetailLabel?.isHidden = subtitle?.isEmpty ?? true
             
             tableCell.cellImageView?.accessibilityLabel = stormImage?.accessibilityLabel
             tableCell.cellImageView?.isAccessibilityElement = stormImage?.accessibilityLabel != nil

--- a/ThunderCloud/OrderedListItem.swift
+++ b/ThunderCloud/OrderedListItem.swift
@@ -29,8 +29,8 @@ open class OrderedListItem: ListItem {
 		super.configure(cell: cell, at: indexPath, in: tableViewController)
 		
 		guard let numberCell = cell as? NumberedViewCell else { return }
-		
 		numberCell.numberLabel.text = number
+        numberCell.numberLabel.font = ThemeManager.shared.theme.dynamicFont(ofSize: 28, textStyle: .title2, weight: .medium)
 	}
 	
 	override open var accessoryType: UITableViewCell.AccessoryType? {

--- a/ThunderCloud/OrderedListItem.swift
+++ b/ThunderCloud/OrderedListItem.swift
@@ -11,36 +11,36 @@ import ThunderTable
 
 /// `OrderedListItem` is a subclass of `ListItem` which represents a row with a number on the left. They will always be correctly ordered from the CMS (1, 2, 3...)
 open class OrderedListItem: ListItem {
-	
-	/// The number to be displayed on the row
-	public var number: String?
-	
-	required public init(dictionary: [AnyHashable : Any]) {
-		super.init(dictionary: dictionary)
-		number = dictionary["annotation"] as? String
-	}
-	
-	override open var cellClass: UITableViewCell.Type? {
-		return NumberedViewCell.self
-	}
-	
-	override open func configure(cell: UITableViewCell, at indexPath: IndexPath, in tableViewController: TableViewController) {
-		
-		super.configure(cell: cell, at: indexPath, in: tableViewController)
-		
-		guard let numberCell = cell as? NumberedViewCell else { return }
-		numberCell.numberLabel.text = number
+    
+    /// The number to be displayed on the row
+    public var number: String?
+    
+    required public init(dictionary: [AnyHashable : Any]) {
+        super.init(dictionary: dictionary)
+        number = dictionary["annotation"] as? String
+    }
+    
+    override open var cellClass: UITableViewCell.Type? {
+        return NumberedViewCell.self
+    }
+    
+    override open func configure(cell: UITableViewCell, at indexPath: IndexPath, in tableViewController: TableViewController) {
+        
+        super.configure(cell: cell, at: indexPath, in: tableViewController)
+        
+        guard let numberCell = cell as? NumberedViewCell else { return }
+        numberCell.numberLabel.text = number
         numberCell.numberLabel.font = ThemeManager.shared.theme.dynamicFont(ofSize: 28, textStyle: .title2, weight: .medium)
-	}
-	
-	override open var accessoryType: UITableViewCell.AccessoryType? {
-		get {
-			return UITableViewCell.AccessoryType.none
-		}
-		set {}
-	}
-	
-	override open var selectionStyle: UITableViewCell.SelectionStyle? {
-		return UITableViewCell.SelectionStyle.none
-	}
+    }
+    
+    override open var accessoryType: UITableViewCell.AccessoryType? {
+        get {
+            return UITableViewCell.AccessoryType.none
+        }
+        set {}
+    }
+    
+    override open var selectionStyle: UITableViewCell.SelectionStyle? {
+        return UITableViewCell.SelectionStyle.none
+    }
 }

--- a/ThunderCloud/QuizCompletionViewController.swift
+++ b/ThunderCloud/QuizCompletionViewController.swift
@@ -49,6 +49,14 @@ extension QuizQuestion: Row {
             numberCell.numberLabel.isHidden = true
         }
         
+        numberCell.cellTextLabel?.isHidden = title == nil || title!.isEmpty
+        numberCell.cellDetailLabel?.isHidden = subtitle == nil || subtitle!.isEmpty
+        
+        numberCell.cellTextLabel?.font = ThemeManager.shared.theme.cellTitleFont
+        numberCell.cellDetailLabel?.font = ThemeManager.shared.theme.cellDetailFont
+        
+        numberCell.numberLabel.font = ThemeManager.shared.theme.dynamicFont(ofSize: 28, textStyle: .title2, weight: .medium)
+        
         // We have no links so make sure to get rid of the spacing on mainStackView
         numberCell.mainStackView?.spacing = 0
     }

--- a/ThunderCloud/QuizCompletionViewController.swift
+++ b/ThunderCloud/QuizCompletionViewController.swift
@@ -49,8 +49,8 @@ extension QuizQuestion: Row {
             numberCell.numberLabel.isHidden = true
         }
         
-        numberCell.cellTextLabel?.isHidden = title == nil || title!.isEmpty
-        numberCell.cellDetailLabel?.isHidden = subtitle == nil || subtitle!.isEmpty
+        numberCell.cellTextLabel?.isHidden = title?.isEmpty ?? true
+        numberCell.cellDetailLabel?.isHidden = subtitle?.isEmpty ?? true
         
         numberCell.cellTextLabel?.font = ThemeManager.shared.theme.cellTitleFont
         numberCell.cellDetailLabel?.font = ThemeManager.shared.theme.cellDetailFont

--- a/ThunderCloud/StormTableRow.swift
+++ b/ThunderCloud/StormTableRow.swift
@@ -22,8 +22,8 @@ open class StormTableRow: TableRow {
 		
 		guard let tableCell = cell as? StormTableViewCell else { return }
         
-        tableCell.cellTextLabel?.isHidden = title == nil || title!.isEmpty
-        tableCell.cellDetailLabel?.isHidden = subtitle == nil || subtitle!.isEmpty
+        tableCell.cellTextLabel?.isHidden = title?.isEmpty ?? true
+        tableCell.cellDetailLabel?.isHidden = subtitle?.isEmpty ?? true
         
         tableCell.cellImageView?.isHidden = image == nil && imageURL == nil
         tableCell.cellTextLabel?.font = ThemeManager.shared.theme.cellTitleFont

--- a/ThunderCloud/StormTableRow.swift
+++ b/ThunderCloud/StormTableRow.swift
@@ -21,6 +21,13 @@ open class StormTableRow: TableRow {
 		super.configure(cell: cell, at: indexPath, in: tableViewController)
 		
 		guard let tableCell = cell as? StormTableViewCell else { return }
+        
+        tableCell.cellTextLabel?.isHidden = title == nil || title!.isEmpty
+        tableCell.cellDetailLabel?.isHidden = subtitle == nil || subtitle!.isEmpty
+        
+        tableCell.cellImageView?.isHidden = image == nil && imageURL == nil
+        tableCell.cellTextLabel?.font = ThemeManager.shared.theme.cellTitleFont
+        tableCell.cellDetailLabel?.font = ThemeManager.shared.theme.cellDetailFont
 		
 		// If we have no links make sure to get rid of the spacing on mainStackView
 		tableCell.mainStackView?.spacing = 0

--- a/ThunderCloud/StormTableRow.swift
+++ b/ThunderCloud/StormTableRow.swift
@@ -11,16 +11,16 @@ import ThunderTable
 
 /// `StormTableRow` is a `TableRow` with added functionality to support right to left languages
 open class StormTableRow: TableRow {
-	
+    
     override open var cellClass: UITableViewCell.Type? {
         return StormObjectFactory.shared.class(for: String(describing: StormTableViewCell.self)) as? StormTableViewCell.Type ?? StormTableViewCell.self
-	}
-	
+    }
+    
     override open func configure(cell: UITableViewCell, at indexPath: IndexPath, in tableViewController: TableViewController) {
-		
-		super.configure(cell: cell, at: indexPath, in: tableViewController)
-		
-		guard let tableCell = cell as? StormTableViewCell else { return }
+        
+        super.configure(cell: cell, at: indexPath, in: tableViewController)
+        
+        guard let tableCell = cell as? StormTableViewCell else { return }
         
         tableCell.cellTextLabel?.isHidden = title?.isEmpty ?? true
         tableCell.cellDetailLabel?.isHidden = subtitle?.isEmpty ?? true
@@ -28,19 +28,19 @@ open class StormTableRow: TableRow {
         tableCell.cellImageView?.isHidden = image == nil && imageURL == nil
         tableCell.cellTextLabel?.font = ThemeManager.shared.theme.cellTitleFont
         tableCell.cellDetailLabel?.font = ThemeManager.shared.theme.cellDetailFont
-		
-		// If we have no links make sure to get rid of the spacing on mainStackView
-		tableCell.mainStackView?.spacing = 0
-		tableCell.embeddedLinksStackView.isHidden = true
-				
-		guard StormLanguageController.shared.isRightToLeft else { return }
-		
-		tableCell.contentView.subviews.forEach { (view) in
-			guard let label = view as? UILabel else {
-				return
-			}
-			
-			label.textAlignment = .right
-		}
-	}
+        
+        // If we have no links make sure to get rid of the spacing on mainStackView
+        tableCell.mainStackView?.spacing = 0
+        tableCell.embeddedLinksStackView.isHidden = true
+        
+        guard StormLanguageController.shared.isRightToLeft else { return }
+        
+        tableCell.contentView.subviews.forEach { (view) in
+            guard let label = view as? UILabel else {
+                return
+            }
+            
+            label.textAlignment = .right
+        }
+    }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds dynamic font sizing and shows/hides text labels (and image view)… in `StormTableRow` to fix dynamic font sizes on quiz completion (Failed) screen.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
ADA work!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by pointing at this branch locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
