### PR TITLE
Makes sure `".jpeg"` files in the bundle don't break the file exists check

### DIFF
--- a/ThunderCloud/ContentController.swift
+++ b/ThunderCloud/ContentController.swift
@@ -12,6 +12,14 @@ import ThunderBasics
 import UIKit
 import os
 
+extension String {
+    /// Returns a Boolean value indicating whether the string contains any of the given elements.
+    /// - Parameter containedStrings: The substrings to check for
+    func containsOneOf<T: StringProtocol>(_ containedStrings: [T]) -> Bool {
+        return containedStrings.contains(where: { self.contains($0) })
+    }
+}
+
 let DOWNLOAD_REQUEST_TAG: Int = "TSCBundleRequestTag".hashValue
 
 // This needs to stay like this, it was a mistake, but without a migration piece just leave it be
@@ -1256,10 +1264,12 @@ public extension ContentController {
         var thinnedAssetName = URL(fileURLWithPath: file).lastPathComponent
         let lastUnderScoreComponent = thinnedAssetName.components(separatedBy: "_").last
         
+        let extensions = [".jpg", ".jpeg", ".png"]
+        
         // Because of the app thinner, files in the original content directory have been removed
         // And moved to the Bundle.xcassets, so lets check for them in there.
         if let _lastUnderScoreComponent = lastUnderScoreComponent, _lastUnderScoreComponent != thinnedAssetName &&
-            (_lastUnderScoreComponent.contains(".png") || _lastUnderScoreComponent.contains(".jpg")) {
+            _lastUnderScoreComponent.containsOneOf(extensions) {
             
             thinnedAssetName = thinnedAssetName.replacingOccurrences(of: "_\(_lastUnderScoreComponent)", with: "")
         }
@@ -1272,9 +1282,10 @@ public extension ContentController {
         if var imageSize = lastUnderScoreComponent {
             
             // Replace these for a later check
-            imageSize = imageSize.replacingOccurrences(of: ".jpg", with: "")
-            imageSize = imageSize.replacingOccurrences(of: ".png", with: "")
-            
+            extensions.forEach { (fileExtension) in
+                imageSize = imageSize.replacingOccurrences(of: fileExtension, with: "")
+            }
+                        
             return imageSize == "x1.5" || imageSize == "x0.75"
         }
         

--- a/ThunderCloud/ContentController.swift
+++ b/ThunderCloud/ContentController.swift
@@ -15,6 +15,7 @@ import os
 extension String {
     /// Returns a Boolean value indicating whether the string contains any of the given elements.
     /// - Parameter containedStrings: The substrings to check for
+    /// - Parameter caseSensitive: Whether the check should run in a case sensitive manner
     func containsOneOf(_ containedStrings: [String], caseSensitive: Bool = true) -> Bool {
         let caseSensitiveSelf = caseSensitive ? self : lowercased()
         let caseSensitiveContainedStrings = caseSensitive ? containedStrings : containedStrings.map({ $0.lowercased() })

--- a/ThunderCloud/ContentController.swift
+++ b/ThunderCloud/ContentController.swift
@@ -16,7 +16,7 @@ extension String {
     /// Returns a Boolean value indicating whether the string contains any of the given elements.
     /// - Parameter containedStrings: The substrings to check for
     func containsOneOf(_ containedStrings: [String], caseSensitive: Bool = true) -> Bool {
-        let caseSensitiveSelf = caseSensitive ? lowercased() : self
+        let caseSensitiveSelf = caseSensitive ? self : lowercased()
         let caseSensitiveContainedStrings = caseSensitive ? containedStrings : containedStrings.map({ $0.lowercased() })
         return caseSensitiveContainedStrings.contains(where: { caseSensitiveSelf.contains($0) })
     }

--- a/ThunderCloud/ContentController.swift
+++ b/ThunderCloud/ContentController.swift
@@ -15,8 +15,10 @@ import os
 extension String {
     /// Returns a Boolean value indicating whether the string contains any of the given elements.
     /// - Parameter containedStrings: The substrings to check for
-    func containsOneOf<T: StringProtocol>(_ containedStrings: [T]) -> Bool {
-        return containedStrings.contains(where: { self.contains($0) })
+    func containsOneOf(_ containedStrings: [String], caseSensitive: Bool = true) -> Bool {
+        let caseSensitiveSelf = caseSensitive ? lowercased() : self
+        let caseSensitiveContainedStrings = caseSensitive ? containedStrings : containedStrings.map({ $0.lowercased() })
+        return caseSensitiveContainedStrings.contains(where: { caseSensitiveSelf.contains($0) })
     }
 }
 
@@ -1269,7 +1271,7 @@ public extension ContentController {
         // Because of the app thinner, files in the original content directory have been removed
         // And moved to the Bundle.xcassets, so lets check for them in there.
         if let _lastUnderScoreComponent = lastUnderScoreComponent, _lastUnderScoreComponent != thinnedAssetName &&
-            _lastUnderScoreComponent.containsOneOf(extensions) {
+            _lastUnderScoreComponent.containsOneOf(extensions, caseSensitive: false) {
             
             thinnedAssetName = thinnedAssetName.replacingOccurrences(of: "_\(_lastUnderScoreComponent)", with: "")
         }
@@ -1283,7 +1285,7 @@ public extension ContentController {
             
             // Replace these for a later check
             extensions.forEach { (fileExtension) in
-                imageSize = imageSize.replacingOccurrences(of: fileExtension, with: "")
+                imageSize = imageSize.lowercased().replacingOccurrences(of: fileExtension, with: "")
             }
                         
             return imageSize == "x1.5" || imageSize == "x0.75"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added `jpeg` into Boolean logic contained in `fileExistsInBundle` function in content controller.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This caused an issue where if a delta update's `manifest.json` had a file in with the `.jpeg` extension, due to this file extension being missed in the `fileExistsInBundle` function if the file was moved to `Bundle.xcassets` by the `AppThinner` tool, then the bundle would incorrectly be marked as invalid!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Has been tested by pointing at this branch locally in the Blood project.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.