### PR TITLE
Adds additional fix for fetching images with the "jpeg" extension

### DIFF
--- a/ThunderCloud/StormGenerator.swift
+++ b/ThunderCloud/StormGenerator.swift
@@ -338,7 +338,9 @@ public class StormGenerator: NSObject {
         
         var thinnedAssetName = imageURL.lastPathComponent
         
-        if let lastUnderscoreComponent = thinnedAssetName.components(separatedBy: "_").last, lastUnderscoreComponent != thinnedAssetName && (lastUnderscoreComponent.contains(".png") || lastUnderscoreComponent.contains(".jpg")) {
+        let imageExtensions = StormImage.validExtensions.map({ "." + $0 })
+        
+        if let lastUnderscoreComponent = thinnedAssetName.components(separatedBy: "_").last, lastUnderscoreComponent != thinnedAssetName && lastUnderscoreComponent.containsOneOf(imageExtensions, caseSensitive: false) {
             thinnedAssetName = thinnedAssetName.replacingOccurrences(of: "_\(lastUnderscoreComponent)", with: "")
         }
         


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes issue where images with ".jpeg" extension aren't pulled correctly from xcassets

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes images not rendering correctly

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It hasn't been I'm afraid, but a very similar fix (identical if statement) was fixed in #241 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
