### PR TITLE
Hotfix/navigation bar appearance

### DIFF
--- a/ThunderCloud.xcodeproj/project.pbxproj
+++ b/ThunderCloud.xcodeproj/project.pbxproj
@@ -229,6 +229,7 @@
 		B1E8C9391DE33144006C1A5C /* DeveloperMode.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B1E8C9381DE33144006C1A5C /* DeveloperMode.storyboard */; };
 		B1E8C93B1DE33200006C1A5C /* DownloadingStormBundleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1E8C93A1DE33200006C1A5C /* DownloadingStormBundleViewController.swift */; };
 		B1FE3A8F22292D5500AB452F /* Language+Preferred.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FE3A8522292D5500AB452F /* Language+Preferred.swift */; };
+		B80AE3292416737A003C9C6E /* SystemViewController+Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80AE3282416737A003C9C6E /* SystemViewController+Notification.swift */; };
 		B8EEB23A238FFD41006E0A73 /* DateFormatter+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8EEB239238FFD41006E0A73 /* DateFormatter+Extensions.swift */; };
 		C284D48919C83FF300DA5EE3 /* ThunderCloud.h in Headers */ = {isa = PBXBuildFile; fileRef = C284D48819C83FF300DA5EE3 /* ThunderCloud.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C284D57319C8400E00DA5EE3 /* StormAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C284D49019C8400D00DA5EE3 /* StormAssets.xcassets */; };
@@ -487,6 +488,7 @@
 		B1E8C9381DE33144006C1A5C /* DeveloperMode.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = DeveloperMode.storyboard; sourceTree = "<group>"; };
 		B1E8C93A1DE33200006C1A5C /* DownloadingStormBundleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownloadingStormBundleViewController.swift; sourceTree = "<group>"; };
 		B1FE3A8522292D5500AB452F /* Language+Preferred.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Language+Preferred.swift"; sourceTree = "<group>"; };
+		B80AE3282416737A003C9C6E /* SystemViewController+Notification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SystemViewController+Notification.swift"; sourceTree = "<group>"; };
 		B8EEB239238FFD41006E0A73 /* DateFormatter+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Extensions.swift"; sourceTree = "<group>"; };
 		C284D46F19C83FC600DA5EE3 /* ThunderCloud.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ThunderCloud.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C284D47319C83FC600DA5EE3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -567,6 +569,7 @@
 				B1188CDD22C4C0E50017A003 /* Analytics+Firebase.swift */,
 				B1898C9D230C2E3A00A1F5D1 /* UIAccessibility+ButtonShapes.swift */,
 				B8EEB239238FFD41006E0A73 /* DateFormatter+Extensions.swift */,
+				B80AE3282416737A003C9C6E /* SystemViewController+Notification.swift */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -1447,6 +1450,7 @@
 				B137790F2028AF58006FE6D5 /* ImageSelectionCollectionViewCell.swift in Sources */,
 				B14834C922C3D6BF00A6D03D /* Analytics+GA.swift in Sources */,
 				B1163E7B1F0CF86A00A9E8E2 /* HeaderListItem.swift in Sources */,
+				B80AE3292416737A003C9C6E /* SystemViewController+Notification.swift in Sources */,
 				B139044B1F8D174300B52DCF /* NavigationController.swift in Sources */,
 				B13DE0D41F0D2BEF00C6B9B7 /* AnnotatedListItemView.swift in Sources */,
 				B1898CA0230D35D800A1F5D1 /* LegacySpotlightListItemCell.swift in Sources */,

--- a/ThunderCloud/AppCollectionCell.swift
+++ b/ThunderCloud/AppCollectionCell.swift
@@ -100,6 +100,10 @@ public extension AppCollectionCell {
                 
             })
             storeViewController.delegate = self
+            
+            // Notify we will present a system `UIViewController`
+            NotificationCenter.default.post(sender: self, present: true, systemViewController: storeViewController)
+            
             parentViewController?.navigationController?.present(storeViewController, animated: true, completion: nil)
         }
     }
@@ -112,6 +116,10 @@ extension AppCollectionCell: SKStoreProductViewControllerDelegate {
     
     public func productViewControllerDidFinish(_ viewController: SKStoreProductViewController) {
         UINavigationBar.appearance().tintColor = .white
+        
+        // Notify we will dismiss a system `UIViewController`
+        NotificationCenter.default.post(sender: self, present: false, systemViewController: viewController)
+        
         viewController.dismissAnimated()
     }
 }

--- a/ThunderCloud/NavigationController+Conformance.swift
+++ b/ThunderCloud/NavigationController+Conformance.swift
@@ -30,6 +30,11 @@ extension UINavigationController: MFMessageComposeViewControllerDelegate {
         // Notify we will dismiss a system `UIViewController`
         NotificationCenter.default.post(sender: self, present: false, systemViewController: controller)
         
+        // Rollback appearance changes made before presenting
+        UIBarButtonItem.appearance().setTitleTextAttributes([
+            .foregroundColor : ThemeManager.shared.theme.navigationBarTintColor
+        ], for: .normal)
+        
         // Dismiss the view controller
         controller.dismissAnimated()
     }

--- a/ThunderCloud/NavigationController+Conformance.swift
+++ b/ThunderCloud/NavigationController+Conformance.swift
@@ -15,12 +15,22 @@ import ThunderTable
 extension UINavigationController: SFSafariViewControllerDelegate {
     
     public func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
+        // Notify we will dismiss a system `UIViewController`
+        NotificationCenter.default.post(sender: self, present: false, systemViewController: controller)
+        
         controller.dismissAnimated()
     }
 }
 
 extension UINavigationController: MFMessageComposeViewControllerDelegate {
-    public func messageComposeViewController(_ controller: MFMessageComposeViewController, didFinishWith result: MessageComposeResult) {
+    public func messageComposeViewController(
+        _ controller: MFMessageComposeViewController,
+        didFinishWith result: MessageComposeResult
+    ){
+        // Notify we will dismiss a system `UIViewController`
+        NotificationCenter.default.post(sender: self, present: false, systemViewController: controller)
+        
+        // Dismiss the view controller
         controller.dismissAnimated()
     }
 }
@@ -28,6 +38,8 @@ extension UINavigationController: MFMessageComposeViewControllerDelegate {
 extension UINavigationController: SKStoreProductViewControllerDelegate {
     
     public func productViewControllerDidFinish(_ viewController: SKStoreProductViewController) {
+        // Notify we will dismiss a system `UIViewController`
+        NotificationCenter.default.post(sender: self, present: false, systemViewController: viewController)
         
         UINavigationBar.appearance().tintColor = ThemeManager.shared.theme.navigationBarTintColor
         viewController.dismissAnimated()

--- a/ThunderCloud/NavigationController.swift
+++ b/ThunderCloud/NavigationController.swift
@@ -13,6 +13,8 @@ import StoreKit
 import ThunderTable
 import AVKit
 
+// MARK: - NavigationBarDataSource
+
 /// Any `UIViewController` can comply to this delegate. The extension provided in this file uses this method to style the navigation bar
 public protocol NavigationBarDataSource {
     
@@ -247,6 +249,9 @@ public extension UINavigationController {
         
         viewController.loadProduct(withParameters: [SKStoreProductParameterITunesItemIdentifier: iTunesIdentifier], completionBlock: nil)
         
+        // Notify we will present a system `UIViewController`
+        NotificationCenter.default.post(sender: self, present: true, systemViewController: viewController)
+        
         present(viewController, animated: true, completion: nil)
     }
     
@@ -284,6 +289,13 @@ public extension UINavigationController {
             
             safariViewController.preferredControlTintColor = ThemeManager.shared.theme.titleTextColor
             safariViewController.preferredBarTintColor = ThemeManager.shared.theme.navigationBarBackgroundColor
+            
+            // Notify we will present a system `UIViewController`
+            NotificationCenter.default.post(
+                sender: self,
+                present: true,
+                systemViewController: safariViewController
+            )
             
             navigationController.present(safariViewController, animated: true, completion: nil)
         }
@@ -398,7 +410,9 @@ public extension UINavigationController {
             controller.body = link.body
             controller.recipients = link.recipients
             controller.messageComposeDelegate = self
-            controller.navigationBar.tintColor = navigationBar.tintColor
+            
+            // Notify we will present a system `UIViewController`
+            NotificationCenter.default.post(sender: self, present: true, systemViewController: controller)
             
             present(controller, animated: true, completion: nil)
             

--- a/ThunderCloud/NavigationController.swift
+++ b/ThunderCloud/NavigationController.swift
@@ -403,10 +403,14 @@ public extension UINavigationController {
     }
     
     private func handleSMS(link: StormLink) {
-        
-        let controller = MFMessageComposeViewController()
+    
         if MFMessageComposeViewController.canSendText() {
+            // Define explicit appearance changes
+            UIBarButtonItem.appearance().setTitleTextAttributes([
+                .foregroundColor : UIColor.systemBlue
+            ], for: .normal)
             
+            let controller = MFMessageComposeViewController()
             controller.body = link.body
             controller.recipients = link.recipients
             controller.messageComposeDelegate = self

--- a/ThunderCloud/SystemViewController+Notification.swift
+++ b/ThunderCloud/SystemViewController+Notification.swift
@@ -10,7 +10,7 @@ import Foundation
 
 // MARK: - Notification.Name
 
-/// Key for user info when sending
+/// Key for user info before presenting or dismissing a system `UIViewController`
 public let systemViewControllerUserInfoKey = "com.3sidedcube.systemViewController"
 
 extension Notification.Name {

--- a/ThunderCloud/SystemViewController+Notification.swift
+++ b/ThunderCloud/SystemViewController+Notification.swift
@@ -1,0 +1,50 @@
+//
+//  SystemViewController+Notification.swift
+//  ThunderCloud
+//
+//  Created by Ben Shutt on 09/03/2020.
+//  Copyright © 2020 threesidedcube. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - Notification.Name
+
+/// Key for user info when sending
+public let systemViewControllerUserInfoKey = "com.3sidedcube.systemViewController"
+
+extension Notification.Name {
+    
+    /// Called before `present(:animated:completion)` is called on a system view controller.
+    /// E.g. `MFMessageComposeViewController`
+    public static let willPresentSystemViewController =
+        Notification.Name(rawValue: "com.3sidedcube.willPresentSystemViewController")
+    
+    /// Called before dismissing a system view controller.
+    /// E.g. `MFMessageComposeViewController`
+    public static let willDismissSystemViewController =
+        Notification.Name(rawValue: "com.3sidedcube.willDismissSystemViewController")
+}
+
+extension Notification {
+    
+    /// `UIViewController` from `userInfo` of `self`
+    public var viewController: UIViewController? {
+        return userInfo?[systemViewControllerUserInfoKey] as? UIViewController
+    }
+}
+
+extension NotificationCenter {
+    
+    func post(sender: Any, present: Bool, systemViewController: UIViewController) {
+        let name: Notification.Name = present ?
+            .willPresentSystemViewController :
+            .willDismissSystemViewController
+        
+        post(
+            name: name,
+            object: sender,
+            userInfo: [systemViewControllerUserInfoKey : systemViewController]
+        )
+    }
+}

--- a/ThunderCloud/SystemViewController+Notification.swift
+++ b/ThunderCloud/SystemViewController+Notification.swift
@@ -29,7 +29,7 @@ extension Notification.Name {
 extension Notification {
     
     /// `UIViewController` from `userInfo` of `self`
-    public var viewController: UIViewController? {
+    public var systemViewController: UIViewController? {
         return userInfo?[systemViewControllerUserInfoKey] as? UIViewController
     }
 }


### PR DESCRIPTION
## Description
When presenting an `MFMessageComposeViewController` the cancel button would be invisible if the bar button items are white.

## Note
The `NotificationCenter` behavior here will not solve the problem (colors set on `init`), but it's useful to have it, so left it in. Happy to remove if you feel it's unnecessary. 

## Motivation and Context
Fix issue in referencing apps

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
