### PR TITLE
Select default accessibility element when showing Quiz completion (not correct state)

### DIFF
--- a/ThunderCloud/QuizCompletionViewController.swift
+++ b/ThunderCloud/QuizCompletionViewController.swift
@@ -290,6 +290,17 @@ open class QuizCompletionViewController: TableViewController {
     
     override open func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        
+        // ARCFA-329: require that the first element starts reading on voice
+        // over when the user goes to this page, force it here.
+        guard !quiz.answeredCorrectly,
+            UIAccessibility.isVoiceOverRunning,
+            let cell = tableView.cellForRow(
+                at: IndexPath(row: 0, section: 0)
+            ) else {
+                return
+        }
+        UIAccessibility.post(notification: .screenChanged, argument: cell)
     }
     
     override open func viewWillLayoutSubviews() {


### PR DESCRIPTION
## Description
Post `UIAccessibility` notification on `viewDidAppear` in `QuizCompletionViewController` passing the first table row

## Motivation and Context
To address a support issue to select the default accessibility element when showing Quiz completion (not correct state).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
