### PR TITLE
Fix/corner radius masking

### DIFF
--- a/ThunderCloud/ImageSelectionCollectionViewCell.swift
+++ b/ThunderCloud/ImageSelectionCollectionViewCell.swift
@@ -24,6 +24,7 @@ class ImageSelectionCollectionViewCell: UICollectionViewCell {
         
         imageView.layer.borderColor = ThemeManager.shared.theme.mainColor.cgColor
         imageView.layer.cornerRadius = 8.0
+        imageView.layer.masksToBounds = true
         labelContainerView.layer.cornerRadius = 8.0
         
         clipsToBounds = false

--- a/ThunderCloud/SpotlightListItemCell.swift
+++ b/ThunderCloud/SpotlightListItemCell.swift
@@ -44,6 +44,7 @@ public class SpotlightCollectionViewCell: UICollectionViewCell {
         super.awakeFromNib()
         
         shadowView.layer.cornerRadius = SpotlightListItemCell.cornerRadius
+        containerView.layer.masksToBounds = true
         containerView.layer.cornerRadius = SpotlightListItemCell.cornerRadius
         containerView.layer.borderWidth = SpotlightListItemCell.borderWidth
         containerView.layer.borderColor = UIColor(white: 0.761, alpha: 1.0).cgColor


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes un-masked views caused by `ThunderBasics` v2.0.0 no longer setting `masksToBounds` for non-zero corner radius

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally by pointing to this branch in gdpc-first-aid

## Screenshots (if appropriate):

![Simulator Screen Shot - iPhone Xs Max - 2020-09-21 at 16 14 27](https://user-images.githubusercontent.com/9033831/93785258-c823cb80-fc25-11ea-840f-f7c20b110706.png)
![Uploading Simulator Screen Shot - iPhone Xs Max - 2020-09-21 at 16.14.00.png…]()

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
