### PR TITLE
Adds back in a default shadow to `CollectionItemViewCell`

### DIFF
--- a/ThunderCloud/CircleProgressView.swift
+++ b/ThunderCloud/CircleProgressView.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import ThunderBasics
 
 /// Circular `UIView` which strokes a `progressPath` on a `backgroundPath`.
 open class CircleProgressView: UIView {
@@ -35,29 +36,13 @@ open class CircleProgressView: UIView {
         }
     }
     
-    /// The shadow colour, defaults to .lightGray
-    var shadowColor: UIColor = .lightGray {
-        didSet {
-            updateShadow()
-        }
-    }
-    
-    /// The opacity of the shadow, defaults to 0.75
-    var shadowOpacity: Float = 0.75 {
-        didSet {
-            updateShadow()
-        }
-    }
-    
-    /// The offset of the shadow, defaults to `.zero`
-    var shadowOffset: CGSize = .zero {
-        didSet {
-            updateShadow()
-        }
-    }
-    
-    /// The radius of the shadow, defaults to `3`
-    var shadowRadius: CGFloat = 3 {
+    /// The shadow components to be applied if `hasShadow` = true
+    var shadowComponents: ShadowComponents? = .init(
+        radius: 3,
+        opacity: 0.75,
+        color: .lightGray,
+        offset: .zero
+    ) {
         didSet {
             updateShadow()
         }
@@ -120,10 +105,7 @@ open class CircleProgressView: UIView {
     }
     
     private func updateShadow() {
-        layer.shadowColor = hasShadow ? shadowColor.cgColor : UIColor.black.cgColor
-        layer.shadowOpacity = hasShadow ? shadowOpacity : 0
-        layer.shadowOffset = hasShadow ? shadowOffset : CGSize(width: 0, height: -3)
-        layer.shadowRadius = shadowRadius
+        shadow = hasShadow ? shadowComponents : nil
         layer.shadowPath = shadowPath
     }
     

--- a/ThunderCloud/CircleProgressView.swift
+++ b/ThunderCloud/CircleProgressView.swift
@@ -29,7 +29,7 @@ open class CircleProgressView: UIView {
         }
     }
     
-    /// Apply shadow configuration based on `shadowColor`, `shadowOpacity`, `shadowOffset`, `shadowRadius` properties
+    /// Apply shadow configuration based on `shadowComponents` property
     public var hasShadow = true {
         didSet {
             updateShadow()

--- a/ThunderCloud/CircleProgressView.swift
+++ b/ThunderCloud/CircleProgressView.swift
@@ -28,8 +28,36 @@ open class CircleProgressView: UIView {
         }
     }
     
-    /// Apply default shadow configuration
+    /// Apply shadow configuration based on `shadowColor`, `shadowOpacity`, `shadowOffset`, `shadowRadius` properties
     public var hasShadow = true {
+        didSet {
+            updateShadow()
+        }
+    }
+    
+    /// The shadow colour, defaults to .lightGray
+    var shadowColor: UIColor = .lightGray {
+        didSet {
+            updateShadow()
+        }
+    }
+    
+    /// The opacity of the shadow, defaults to 0.75
+    var shadowOpacity: Float = 0.75 {
+        didSet {
+            updateShadow()
+        }
+    }
+    
+    /// The offset of the shadow, defaults to `.zero`
+    var shadowOffset: CGSize = .zero {
+        didSet {
+            updateShadow()
+        }
+    }
+    
+    /// The radius of the shadow, defaults to `3`
+    var shadowRadius: CGFloat = 3 {
         didSet {
             updateShadow()
         }
@@ -92,10 +120,10 @@ open class CircleProgressView: UIView {
     }
     
     private func updateShadow() {
-        layer.shadowColor = hasShadow ? UIColor.lightGray.cgColor : UIColor.black.cgColor
-        layer.shadowOpacity = hasShadow ? 0.75 : 0
-        layer.shadowOffset = hasShadow ? CGSize(width: 0, height: 0) : CGSize(width: 0, height: -3)
-        layer.shadowRadius = 3
+        layer.shadowColor = hasShadow ? shadowColor.cgColor : UIColor.black.cgColor
+        layer.shadowOpacity = hasShadow ? shadowOpacity : 0
+        layer.shadowOffset = hasShadow ? shadowOffset : CGSize(width: 0, height: -3)
+        layer.shadowRadius = shadowRadius
         layer.shadowPath = shadowPath
     }
     

--- a/ThunderCloud/CollectionItemViewCell.swift
+++ b/ThunderCloud/CollectionItemViewCell.swift
@@ -214,10 +214,15 @@ open class CollectionItemViewCell: UICollectionViewCell {
         } else {
             
             imageViewMargins = .init(top: 6, left: 6, bottom: 6, right: 6)
-            imageBackgroundView.hasShadow = false
             imageBackgroundView.alpha = 1
             imageBackgroundView.progress = 0
             imageBackgroundView.circleProgressLayer.backgroundPathColor = imageBackgroundView.backgroundColor ?? .white
+            
+            imageBackgroundView.shadowRadius = 36
+            imageBackgroundView.shadowColor = UIColor.black
+            imageBackgroundView.shadowOffset = CGSize(width: 0, height: 10)
+            imageBackgroundView.shadowOpacity = 0.1
+            
             imageView.alpha = item.enabled ? 1.0 : 0.4
         }
 

--- a/ThunderCloud/CollectionItemViewCell.swift
+++ b/ThunderCloud/CollectionItemViewCell.swift
@@ -218,10 +218,12 @@ open class CollectionItemViewCell: UICollectionViewCell {
             imageBackgroundView.progress = 0
             imageBackgroundView.circleProgressLayer.backgroundPathColor = imageBackgroundView.backgroundColor ?? .white
             
-            imageBackgroundView.shadowRadius = 36
-            imageBackgroundView.shadowColor = UIColor.black
-            imageBackgroundView.shadowOffset = CGSize(width: 0, height: 10)
-            imageBackgroundView.shadowOpacity = 0.1
+            imageBackgroundView.shadowComponents = .init(
+                radius: 36,
+                opacity: 0.1,
+                color: .black,
+                offset: .init(width: 0, height: 10)
+            )
             
             imageView.alpha = item.enabled ? 1.0 : 0.4
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds back in a shadow to collection item view cell that seems to have been removed at the time that blended learning was merged into develop. I can't recall any legitimate reason for this removal, so this PR is re-instating the exact same shadow that was present before

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Solves shadows not appearing where they should on `CollectionItemViewCell`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested running this branch locally in ARC First Aid

## Screenshots (if appropriate):
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-09-30 at 13 32 51](https://user-images.githubusercontent.com/9033831/94685533-76fc9180-0321-11eb-8f0d-72f480eec1b4.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
