### PR TITLE
Re-PRing portrait iPad changes

### DIFF
--- a/ThunderCloud.xcodeproj/project.pbxproj
+++ b/ThunderCloud.xcodeproj/project.pbxproj
@@ -234,6 +234,7 @@
 		B1BAAC2522254083007F0F61 /* ThunderCloud.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = C284D46F19C83FC600DA5EE3 /* ThunderCloud.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B1BAAC2622254255007F0F61 /* StormLink+Localised.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB956E51F6FE7FA007F3FD1 /* StormLink+Localised.swift */; };
 		B1BAAD102226A67F007F0F61 /* LocalisationLocaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1BAAD0F2226A67F007F0F61 /* LocalisationLocaleTests.swift */; };
+		B1CF495E2534A3A8008819E2 /* StormObjectFactory+AppViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1CF495D2534A3A8008819E2 /* StormObjectFactory+AppViewController.swift */; };
 		B1E029C31FA32239007D1613 /* AccordionTabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1E029C21FA32239007D1613 /* AccordionTabBarViewController.swift */; };
 		B1E029CC1FA3343A007D1613 /* AccordionTabBarItemTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1E029CA1FA3343A007D1613 /* AccordionTabBarItemTableViewCell.swift */; };
 		B1E029CD1FA3343A007D1613 /* AccordionTabBarItemTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B1E029CB1FA3343A007D1613 /* AccordionTabBarItemTableViewCell.xib */; };
@@ -536,6 +537,7 @@
 		B1B806352434E0E900112B3D /* LoggerConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerConstants.swift; sourceTree = "<group>"; };
 		B1BAAC2222253D7A007F0F61 /* NavigationController+Conformance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NavigationController+Conformance.swift"; sourceTree = "<group>"; };
 		B1BAAD0F2226A67F007F0F61 /* LocalisationLocaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalisationLocaleTests.swift; sourceTree = "<group>"; };
+		B1CF495D2534A3A8008819E2 /* StormObjectFactory+AppViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StormObjectFactory+AppViewController.swift"; sourceTree = "<group>"; };
 		B1E029C21FA32239007D1613 /* AccordionTabBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccordionTabBarViewController.swift; sourceTree = "<group>"; };
 		B1E029CA1FA3343A007D1613 /* AccordionTabBarItemTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccordionTabBarItemTableViewCell.swift; sourceTree = "<group>"; };
 		B1E029CB1FA3343A007D1613 /* AccordionTabBarItemTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AccordionTabBarItemTableViewCell.xib; sourceTree = "<group>"; };
@@ -649,6 +651,7 @@
 				B80AE3282416737A003C9C6E /* SystemViewController+Notification.swift */,
 				B14EF99924373F4D00C4BAA3 /* JSONString.swift */,
 				B115915124ACE33300BBF982 /* Styling */,
+				B1CF495D2534A3A8008819E2 /* StormObjectFactory+AppViewController.swift */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -1640,6 +1643,7 @@
 				B10832511F0BCFDF008B565D /* ButtonListItem.swift in Sources */,
 				B108322E1F0B8B37008B565D /* AchievementDisplayView.swift in Sources */,
 				B1898C9E230C2E3A00A1F5D1 /* UIAccessibility+ButtonShapes.swift in Sources */,
+				B1CF495E2534A3A8008819E2 /* StormObjectFactory+AppViewController.swift in Sources */,
 				B13778D520289644006FE6D5 /* QuizSliderViewController.swift in Sources */,
 				B10832241F0A8E8A008B565D /* QuizCompletionViewController.swift in Sources */,
 				B1898C92230C02CB00A1F5D1 /* SpotlightImageListItem.swift in Sources */,

--- a/ThunderCloud/AppViewController.swift
+++ b/ThunderCloud/AppViewController.swift
@@ -21,9 +21,6 @@ open class AppViewController: SplitViewController {
 		
         super.init()
         
-        if #available(iOS 14.0, *) {
-            preferredSplitBehavior = .tile
-        }
         preferredDisplayMode = .oneBesideSecondary
         
         StormLanguageController.shared.reloadLanguagePack()

--- a/ThunderCloud/AppViewController.swift
+++ b/ThunderCloud/AppViewController.swift
@@ -8,12 +8,9 @@
 
 import UIKit
 
-/**
- `TSCAppViewController` is the root class of any Storm CMS driven app. By initialising this class, Storm builds the entire app defined by the JSON files included in the bundle delivered by Storm.
- 
- Allocate an instance of this class and set it to the root view controller of the `UIWindow`.
- 
- */
+/// AppViewController` is the root class of any Storm CMS driven app. By initialising this class, Storm builds the entire app defined by the JSON files included in the bundle delivered by Storm.
+///
+/// Allocate an instance of this class and set it to the root view controller of the `UIWindow`.
 open class AppViewController: SplitViewController {
     
     open override var childForStatusBarStyle: UIViewController? {

--- a/ThunderCloud/AppViewController.swift
+++ b/ThunderCloud/AppViewController.swift
@@ -24,6 +24,11 @@ open class AppViewController: SplitViewController {
 		
         super.init()
         
+        if #available(iOS 14.0, *) {
+            preferredSplitBehavior = .tile
+        }
+        preferredDisplayMode = .oneBesideSecondary
+        
         StormLanguageController.shared.reloadLanguagePack()
         
         let appFileURL = ContentController.shared.fileUrl(forResource: "app", withExtension: "json", inDirectory: nil)

--- a/ThunderCloud/DeveloperModeController.swift
+++ b/ThunderCloud/DeveloperModeController.swift
@@ -240,7 +240,8 @@ public class DeveloperModeController: NSObject {
     /// If your root view controller is not a `TSCAppViewController` overriding this will be necessary
     open var refreshHandler: (_ devMode: Bool) -> (Void) = { (devMode) -> (Void) in
         
-        let appView = AppViewController()
+        let appVCClass: AppViewController.Type = StormObjectFactory.shared.class(for: String(describing: AppViewController.self)) as? AppViewController.Type ?? AppViewController.self
+        let appView = appVCClass.init()
         
         var viewOptions: UIView.AnimationOptions = devMode ? .transitionCurlUp : .transitionCurlDown
         

--- a/ThunderCloud/DeveloperModeController.swift
+++ b/ThunderCloud/DeveloperModeController.swift
@@ -240,8 +240,7 @@ public class DeveloperModeController: NSObject {
     /// If your root view controller is not a `TSCAppViewController` overriding this will be necessary
     open var refreshHandler: (_ devMode: Bool) -> (Void) = { (devMode) -> (Void) in
         
-        let appVCClass: AppViewController.Type = StormObjectFactory.shared.class(for: String(describing: AppViewController.self)) as? AppViewController.Type ?? AppViewController.self
-        let appView = appVCClass.init()
+        let appView = StormObjectFactory.createAppViewController()
         
         var viewOptions: UIView.AnimationOptions = devMode ? .transitionCurlUp : .transitionCurlDown
         

--- a/ThunderCloud/SplitViewController.swift
+++ b/ThunderCloud/SplitViewController.swift
@@ -32,12 +32,8 @@ open class SplitViewController: UISplitViewController {
 		
 		let rightVC = placeholderDetailVCClass.init(nibName: nil, bundle: nil)
 		detailViewController = SplitViewController.navigationController(for: rightVC)
-		
-        if #available(iOS 14.0, *) {
-            super.init(style: .doubleColumn)
-        } else {
-            super.init(nibName: nil, bundle: nil)
-        }
+    
+        super.init(nibName: nil, bundle: nil)
 		
 		view.backgroundColor = .black
 	}

--- a/ThunderCloud/SplitViewController.swift
+++ b/ThunderCloud/SplitViewController.swift
@@ -33,7 +33,11 @@ open class SplitViewController: UISplitViewController {
 		let rightVC = placeholderDetailVCClass.init(nibName: nil, bundle: nil)
 		detailViewController = SplitViewController.navigationController(for: rightVC)
 		
-		super.init(nibName: nil, bundle: nil)
+        if #available(iOS 14.0, *) {
+            super.init(style: .doubleColumn)
+        } else {
+            super.init(nibName: nil, bundle: nil)
+        }
 		
 		view.backgroundColor = .black
 	}

--- a/ThunderCloud/StormLanguageController.swift
+++ b/ThunderCloud/StormLanguageController.swift
@@ -411,9 +411,9 @@ open class StormLanguageController: NSObject {
         NotificationCenter.default.post(name: .languageSwitchedNotification, object: self, userInfo: nil)
         
         
-        let appView = AppViewController()
+        let appVCClass: AppViewController.Type = StormObjectFactory.shared.class(for: String(describing: AppViewController.self)) as? AppViewController.Type ?? AppViewController.self
         let window = UIApplication.shared.keyWindow
-        window?.rootViewController = appView
+        window?.rootViewController = appVCClass.init()
     }
     
     //MARK - Right to left support

--- a/ThunderCloud/StormLanguageController.swift
+++ b/ThunderCloud/StormLanguageController.swift
@@ -409,11 +409,9 @@ open class StormLanguageController: NSObject {
         }
         
         NotificationCenter.default.post(name: .languageSwitchedNotification, object: self, userInfo: nil)
-        
-        
-        let appVCClass: AppViewController.Type = StormObjectFactory.shared.class(for: String(describing: AppViewController.self)) as? AppViewController.Type ?? AppViewController.self
+                
         let window = UIApplication.shared.keyWindow
-        window?.rootViewController = appVCClass.init()
+        window?.rootViewController = StormObjectFactory.createAppViewController()
     }
     
     //MARK - Right to left support

--- a/ThunderCloud/StormObjectFactory+AppViewController.swift
+++ b/ThunderCloud/StormObjectFactory+AppViewController.swift
@@ -1,0 +1,24 @@
+//
+//  StormObjectFactory+AppViewController.swift
+//  ThunderCloud
+//
+//  Created by Simon Mitchell on 12/10/2020.
+//  Copyright © 2020 threesidedcube. All rights reserved.
+//
+
+import Foundation
+
+extension StormObjectFactory {
+    
+    /// Creates an instance of `AppViewController` (or any subclass thereof) taking into account storm overrides
+    /// - Returns: The view controller that was created
+    static func createAppViewController() -> AppViewController {
+        
+        let appViewControllerClass: AppViewController.Type = StormObjectFactory.shared.class(
+            for: String(describing: AppViewController.self)
+        ) as? AppViewController.Type ?? AppViewController.self
+        let appViewController = appViewControllerClass.init()
+        
+        return appViewController
+    }
+}

--- a/ThunderCloud/TSCAppDelegate.swift
+++ b/ThunderCloud/TSCAppDelegate.swift
@@ -94,8 +94,7 @@ open class TSCAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificatio
             window = UIWindow(frame: UIScreen.main.bounds)
         }
         
-        let appVCClass: AppViewController.Type = StormObjectFactory.shared.class(for: String(describing: AppViewController.self)) as? AppViewController.Type ?? AppViewController.self
-        window?.rootViewController = appVCClass.init()
+        window?.rootViewController = StormObjectFactory.createAppViewController()
         window?.makeKeyAndVisible()
     }
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Makes sure split VC on iPad always has master VC shown when in portrait

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix iPad storm apps looking really empty on first launch

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally in BRC First Aid

## Screenshots (if appropriate):
![Simulator Screen Shot - iPad Pro (12 9-inch) (4th generation) - 2020-10-12 at 16 52 18](https://user-images.githubusercontent.com/9033831/95766536-50d4db00-0cab-11eb-87f8-7a8d3a1b9abc.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
