### PR TITLE
Ability to update badge image size outside of framework

### DIFF
--- a/ThunderCloud/CollectionItemViewCell.swift
+++ b/ThunderCloud/CollectionItemViewCell.swift
@@ -68,22 +68,28 @@ public struct CollectionItemViewCellConfiguration {
     public var fixedTitleLabelStyle: CollectionCellDisplayableStyle?
     
     /// Width and height of badge `UIImageView` when blended learning is enabled
-    public var blendedLearningBadgeImageSize: CGFloat
+    public var blendedLearningImageBackgroundSize: CGFloat
     
     /// Width and height of badge `UIImageView`
-    public var badgeImageSize: CGFloat
+    public var imageBackgroundSize: CGFloat
     
     /// Public memberwise init
+    ///
+    /// - Parameters:
+    ///   - showProgressForNonExpirableItems: `Bool`
+    ///   - fixedTitleLabelStyle: `CollectionCellDisplayableStyle`
+    ///   - blendedLearningImageBackgroundSize: `CGFloat`
+    ///   - badgeImageSize: `CGFloat`
     public init(
         showProgressForNonExpirableItems: Bool = false,
         fixedTitleLabelStyle: CollectionCellDisplayableStyle? = nil,
-        blendedLearningBadgeImageSize: CGFloat = 94,
-        badgeImageSize: CGFloat = 76
+        blendedLearningImageBackgroundSize: CGFloat = 94,
+        imageBackgroundSize: CGFloat = 76
     ) {
         self.showProgressForNonExpirableItems = showProgressForNonExpirableItems
         self.fixedTitleLabelStyle = fixedTitleLabelStyle
-        self.blendedLearningBadgeImageSize = blendedLearningBadgeImageSize
-        self.badgeImageSize = badgeImageSize
+        self.blendedLearningImageBackgroundSize = blendedLearningImageBackgroundSize
+        self.imageBackgroundSize = imageBackgroundSize
     }
 }
 
@@ -181,8 +187,8 @@ open class CollectionItemViewCell: UICollectionViewCell {
         
         // Return value based on blended learning
         return isBlendedLearningEnabled ?
-            cellConfiguration.blendedLearningBadgeImageSize :
-            cellConfiguration.badgeImageSize
+            cellConfiguration.blendedLearningImageBackgroundSize :
+            cellConfiguration.imageBackgroundSize
     }
     
     /// Calculates the size of the collection list item for the given item
@@ -221,6 +227,7 @@ open class CollectionItemViewCell: UICollectionViewCell {
         titleAccessibilityLabel = item.accessibilityLabel
         imageView.accessibilityLabel = item.itemImage?.accessibilityLabel
         
+        // Image container size
         imageContainerWidthConstraint.constant = Self.imageBackgroundViewSize()
         
         // Content

--- a/ThunderCloud/CollectionItemViewCell.swift
+++ b/ThunderCloud/CollectionItemViewCell.swift
@@ -221,7 +221,7 @@ open class CollectionItemViewCell: UICollectionViewCell {
         )
     }
     
-    public func configure(with item: CollectionCellDisplayable) {
+    open func configure(with item: CollectionCellDisplayable) {
         
         // Accessibility
         titleAccessibilityLabel = item.accessibilityLabel

--- a/ThunderCloud/CollectionItemViewCell.swift
+++ b/ThunderCloud/CollectionItemViewCell.swift
@@ -79,7 +79,7 @@ public struct CollectionItemViewCellConfiguration {
     ///   - showProgressForNonExpirableItems: `Bool`
     ///   - fixedTitleLabelStyle: `CollectionCellDisplayableStyle`
     ///   - blendedLearningImageBackgroundSize: `CGFloat`
-    ///   - badgeImageSize: `CGFloat`
+    ///   - imageBackgroundSize: `CGFloat`
     public init(
         showProgressForNonExpirableItems: Bool = false,
         fixedTitleLabelStyle: CollectionCellDisplayableStyle? = nil,

--- a/ThunderCloud/CollectionItemViewCell.swift
+++ b/ThunderCloud/CollectionItemViewCell.swift
@@ -121,13 +121,13 @@ open class CollectionItemViewCell: UICollectionViewCell {
     @IBOutlet public weak var titleLabel: InsetLabel!
 
     /// The label for displaying the subtitle of the collection item
-    @IBOutlet weak var subtitleLabel: InsetLabel!
+    @IBOutlet public weak var subtitleLabel: InsetLabel!
     
     /// White background view surrounding the collection item's image
     @IBOutlet public weak var imageBackgroundView: CircleProgressView!
     
     /// The container view for the item's image, so it can be masked to the outer view's corner radius
-    @IBOutlet weak var imageContainerView: UIView! {
+    @IBOutlet public weak var imageContainerView: UIView! {
         didSet {
             imageContainerView.clipsToBounds = true
         }
@@ -221,7 +221,7 @@ open class CollectionItemViewCell: UICollectionViewCell {
         )
     }
     
-    func configure(with item: CollectionCellDisplayable) {
+    public func configure(with item: CollectionCellDisplayable) {
         
         // Accessibility
         titleAccessibilityLabel = item.accessibilityLabel


### PR DESCRIPTION
## Description
Add 
1. `blendedLearningImageBackgroundSize`
2. `imageBackgroundSize` 

properties to `CollectionItemViewCellConfiguration` to configure the quiz badge imageView size.

## Related Issue
https://3sidedcube.atlassian.net/browse/OU20-90

## Motivation and Context
Requested to increase size of badge image in a referencing app

## How Has This Been Tested?
Tested by running in companion app.

## Screenshots (if appropriate):
![IMG_24CE77269E55-1](https://user-images.githubusercontent.com/57952587/97710873-3aed5580-1ab4-11eb-8ea6-dd7c64711c6a.jpeg)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
