### PR TITLE
Fixes icon image not being shared

### DIFF
--- a/ThunderCloud/QuizBadgeCollectionCell.swift
+++ b/ThunderCloud/QuizBadgeCollectionCell.swift
@@ -129,7 +129,7 @@ open class QuizBadgeCollectionCell: CollectionCell {
         let defaultShareBadgeMessage = "Test Completed".localised(with: "_TEST_COMPLETED_SHARE")
         var items: [Any] = []
         
-        if let badgeIcon = quizBadge.badge.icon {
+        if let badgeIcon = quizBadge.badge.icon?.image {
             items.append(badgeIcon)
         }
         


### PR DESCRIPTION
Fixes icon image not being shared

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Badges not being shared properly.  bagdeIcon is a StormImage, which UIActivityViewController doesn't know anything about, it can only work with things like String, and UIImage.
Badges are only shareable via messages and other share functionality when the user shares on the quiz completion screen. If the user shares it the badge is not included, only the share text. 
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
1. Complete a quiz
2. Click share
3. Share the quiz with the badge icon displaying via messages
4. Return to ‘Test’ tab
5. Click completed badge icon
6. Click to share in the same way as test step 2
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
1. The change is required so the user can share the badge icon image. 
2. Solves the issue of icon image not being shared. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
