### PR TITLE
Fixes a bug which would cause the app content to be missing

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,5 +1,5 @@
 github "3sidedcube/ThunderTable" == 1.6.1
 github "3sidedcube/ThunderCollection" == 1.3.1
-github "3sidedcube/ThunderBasics" == 2.0.1
+github "3sidedcube/ThunderBasics" == 2.1.0
 github "3sidedcube/ThunderRequest" == 2.3.1
 github "3sidedcube/Baymax" == 1.2.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "3sidedcube/Baymax" "v1.2.2"
-github "3sidedcube/ThunderBasics" "v2.0.1"
+github "3sidedcube/ThunderBasics" "v2.1.0"
 github "3sidedcube/ThunderCollection" "v1.3.1"
 github "3sidedcube/ThunderRequest" "v2.3.1"
 github "3sidedcube/ThunderTable" "v1.6.1"

--- a/ThunderCloud/TSCAppDelegate.swift
+++ b/ThunderCloud/TSCAppDelegate.swift
@@ -55,6 +55,9 @@ open class TSCAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificatio
             ContentController.shared.appLaunched()
         }
 
+        // It is important that this is called AFTER `ContentController.shared.appLaunched()` otherwise
+        // content can be deleted from under us if the app version
+        // has changed!
         setupRootWindow()
         
         let accessibilityNotifications: [Notification.Name] = [

--- a/ThunderCloud/TSCAppDelegate.swift
+++ b/ThunderCloud/TSCAppDelegate.swift
@@ -36,7 +36,6 @@ open class TSCAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificatio
                 
 		UNUserNotificationCenter.current().delegate = self
 				
-        setupRootWindow()
 		setupSharedUserAgent()
         
         if let remoteNotification = launchOptions?[.remoteNotification] as? [String : Any], let aps = remoteNotification["aps"] as? [AnyHashable : Any] {
@@ -55,6 +54,8 @@ open class TSCAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificatio
             
             ContentController.shared.appLaunched()
         }
+
+        setupRootWindow()
         
         let accessibilityNotifications: [Notification.Name] = [
             UIAccessibility.darkerSystemColorsStatusDidChangeNotification,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If an an app is migrated from one Storm App ID to another
under a version bump then the app would be blank on first launch.

This is caused because if `setupRootWindow` is called before
`ContentController.shared.appLaunched()` is called then the
app.json is loaded from the previous app's delta bundle, which
is then subsequently deleted by the content controller when it
detects an app version change.

This should all be okay and not result in any issues, due to these
calls being synchronous, but it seems that there's some unforseen
asynchronous process which means that the files are deleted by
the content controller before the content is shown on-screen.

Previously this would have only resulted in the user being shown the
same content as the latest delta update for the app in question,
but due to some underlying issue it was resulting in a blank app until
next launch at which point the previous App ID's delta is fully removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally in ARC First Aid by manually calling `appLaunched` before we call `super.appDidFinish...` in the app delegate

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
