### PR TITLE
🟠 Normal: Remove dev mode transition [Small]

### DIFF
--- a/ThunderCloud/DeveloperModeController.swift
+++ b/ThunderCloud/DeveloperModeController.swift
@@ -239,19 +239,9 @@ public class DeveloperModeController: NSObject {
     ///
     /// If your root view controller is not a `TSCAppViewController` overriding this will be necessary
     open var refreshHandler: (_ devMode: Bool) -> (Void) = { (devMode) -> (Void) in
-        
         let appView = StormObjectFactory.createAppViewController()
-        
-        var viewOptions: UIView.AnimationOptions = devMode ? .transitionCurlUp : .transitionCurlDown
-        
         let devModeController = DeveloperModeController.shared
-        
-        guard let currentView = devModeController.appWindow?.rootViewController?.view else { return }
-        
-        UIView.transition(from: currentView, to: appView.view, duration: 1.0, options: viewOptions, completion: { (finished) in
-            
-            devModeController.appWindow?.rootViewController = appView
-        })
+        devModeController.appWindow?.rootViewController = appView
     }
     
     /// A callback which can be used to re-theme the app after leaving dev mode.

--- a/ThunderCloud/DeveloperModeController.swift
+++ b/ThunderCloud/DeveloperModeController.swift
@@ -241,6 +241,8 @@ public class DeveloperModeController: NSObject {
     open var refreshHandler: (_ devMode: Bool) -> (Void) = { (devMode) -> (Void) in
         let appView = StormObjectFactory.createAppViewController()
         let devModeController = DeveloperModeController.shared
+        let window = UIApplication.shared.appKeyWindow
+        window?.rootViewController = appView
         devModeController.appWindow?.rootViewController = appView
     }
     


### PR DESCRIPTION
## What?
Removes the super sexy and on-trend (and I'm pretty sure long since removed by Apple) _**page curl transition**_ that was used when switching in and out of dev mode.

## Why?
SP-1622
This took some tracking down and a half.
BRC First Aid's navigation (nav and tab bars) would become buggy after switching between dev and live bundles. Navigation animations broke, large title preference would be ignored, and navigation elements would disappear (such as back buttons and the BRC logo).
I originally assumed this was to do with the dev theme applied by ThunderCloud, but the issue occurred switching in or out of dev mode - which led me to this transition.

I'm assuming - especially since this is a feature not accessed by users - that removing this transition altogether is fine, but please let me know team if you can see issues with this when applied to our fleet of Storm apps.

## Screen recordings

Issue:
https://user-images.githubusercontent.com/84126596/212673607-195aacc7-de5d-48e2-b974-3e6c9e27d791.mp4

Resolved:
https://user-images.githubusercontent.com/84126596/212673741-4f7ab559-e3b0-43f8-b593-a655afe54578.mp4
