### PR TITLE
🟢 [Small] Fix quiz progress view

### DIFF
--- a/ThunderCloud/QuizQuestionContainerViewController.swift
+++ b/ThunderCloud/QuizQuestionContainerViewController.swift
@@ -333,7 +333,7 @@ open class QuizQuestionContainerViewController: AccessibilityRefreshingViewContr
             progressView.transform = transform
         }
         
-        progressView.progress = Float(quiz.currentIndex) / Float(questions.count)
+        progressView.progress = Float(quiz.currentIndex + 1) / Float(questions.count)
         progressView.set(minY: progressView.frame.minY + 10)
         
         let progressViewHeight: CGFloat = 6
@@ -369,7 +369,7 @@ open class QuizQuestionContainerViewController: AccessibilityRefreshingViewContr
         )
         progressEndCap.layer.cornerRadius = progressViewHeight/2
         progressEndCap.layer.masksToBounds = true
-        progressEndCap.backgroundColor = progressView.trackTintColor
+        progressEndCap.backgroundColor = quiz.currentIndex + 1 == questions.count ? progressView.progressTintColor : progressView.trackTintColor
         progressContainer.addSubview(progressEndCap)
         
         return progressContainer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes an issue where a quiz at 100% progress was not rendering a complete progress bar - the issue stems from an off by 1 error(?). 

## Description
Updates progress view logic on `QuizQuestionContainerViewController` such that:

- The +1 offset is accounted for.
- The progress end cap changes colour to white (progress tint) at 100% progress
- - _Maybe a better solution!_

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Bug effects projects using QuizQuestionContainerViewController. For detailed info check in Jira:
* SP-1896
* SP-1901

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This fixes the bugs raised above - what I would like to know is whether the previous implementation was by design? Is there a reason code-wise or client-wise that the progress bar didn't fill to 100%?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* Built Swim + Pet apps using this branch as the Carthage dependency target
* Ran through quizzes to confirm progress bar fills correctly

## Screenshots (if appropriate):
**Bug**

![old](https://user-images.githubusercontent.com/3648571/235862913-4ebf21d5-80e5-4053-937f-4de0dfde8d28.jpg)

**Fixed**

![fix](https://user-images.githubusercontent.com/3648571/235862922-4f203919-02ee-42d4-a040-294847b49298.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
