### PR TITLE
🔴 High: Fix silent push bundle update crash [Tiny]

### DIFF
--- a/ThunderCloud/ContentController.swift
+++ b/ThunderCloud/ContentController.swift
@@ -1136,8 +1136,14 @@ public class ContentController: NSObject {
             }
             completionHandler(.newData)
         }
-        
-        completionHandler(.newData)
+
+        // Removed due to exception: unbalanced call to dispatch_group_leave().
+        // Likely because the completion handler is called twice
+        // 1. Here, where we have removed
+        // 2. Above completion handler (where it was crashing)
+        // From commit: 6416ac6
+        // In PR: #266
+        // completionHandler(.newData)
     }
     
     /// Downloads a storm bundle from a specific url


### PR DESCRIPTION
Fix silent bundle update pushes crashing apps.

## Description
Remove call to completion handler in `downloadBundle(forNotification:fetchCompletionHandler:)` of `ContentController`.
The Slack threads are better documented, but to summarise:

* Storm sends silent PN to update bundle
* ThunderCloud processes that PN and prepares that update (a.k.a delta)
* Crashes upon calling the remote notification `fetchCompletionHandler` (for the second time) 

## References

* [Initial Slack Thread](https://3sidedcube.slack.com/archives/C024QLJ0T/p1684855713437909)
* [Slack Thread With Stack Trace](https://3sidedcube.slack.com/archives/C024QLJ0T/p1685030910632009)
* [Slack Thread With Explaination](https://3sidedcube.slack.com/archives/C024QLJ0T/p1685092049666039)
* Original PR #266 (April 2020)
* Suspect commit: 6416ac6

## Motivation and Context
Causing crashes in apps. Only present in apps where silent push (for bundle update) is enabled in Storm.

## How Has This Been Tested?
Tested in `feature/fa-bundle` branch where a bare-bones app has been added to ThunderCloud to debug ThunderCloud.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
