### PR TITLE
SP-3010: Make sure the UIAlertController popover presentation shows on iPad

### DIFF
--- a/ThunderCloudSwift/Navigation/NavigationController.swift
+++ b/ThunderCloudSwift/Navigation/NavigationController.swift
@@ -404,36 +404,34 @@ public extension UINavigationController {
     }
     
     private func handleShare(link: StormLink) {
-        
         guard let body = link.body else { return }
-        
+
         let shareController = UIActivityViewController(activityItems: [body], applicationActivities: nil)
         shareController.completionWithItemsHandler = { (activityType, completed, returnedItems, error) in
             
             NotificationCenter.default.sendAnalyticsHook(.shareApp(activityType, completed))
         }
-        
+
         let keyWindow = UIApplication.shared.appKeyWindow
-        
+
         shareController.popoverPresentationController?.sourceView = keyWindow
+        shareController.popoverPresentationController?.permittedArrowDirections = []
+
         if let keyWindow = keyWindow {
-            shareController.popoverPresentationController?.sourceRect = CGRect(x: keyWindow.center.x, y: keyWindow.frame.maxY, width: 100, height: 100)
+            /// Setting the sourceRect to the keyWindow's center, and having the width and the height set to zero
+            /// ensures that the popover will appear in the center of the screen/target page.
+            /// As there is no context for the source of the popover, it would be confusing to show
+            /// an arrow, if the popover has no awareness of where the arrow should point.
+            shareController.popoverPresentationController?.sourceRect = CGRect(x: keyWindow.center.x, y: keyWindow.center.y, width: 0, height: 0)
         }
-        shareController.popoverPresentationController?.permittedArrowDirections = .up
-        
+
         if let splitViewController = keyWindow?.rootViewController as? SplitViewController {
-            
             if UIApplication.shared.appStatusBarOrientation.isLandscape {
-                
                 splitViewController.present(shareController, animated: true, completion: nil)
-                
             } else {
-                
                 splitViewController.primaryViewController.present(shareController, animated: true, completion: nil)
             }
-            
         } else {
-            
             present(shareController, animated: true, completion: nil)
         }
     }


### PR DESCRIPTION
## Description
Make sure the `popoverPresentationController` shows on iPad apps. The sourceRect was out of bounds for presenting on iPad with a `y` position set to the window's `maxY`. I've updated this so that the sourceRect is the center of the page.
```
shareController.popoverPresentationController?.sourceRect = CGRect(x: keyWindow.center.x, y: keyWindow.center.y, width: 0, height: 0)
```
There is more insight from my following comment:
```
/// Setting the sourceRect to the keyWindow's center, and having the width and the height set to zero
/// ensures that the popover will appear in the center of the screen/target page.
/// As there is no context for the source of the popover, it would be confusing to show
/// an arrow, if the popover has no awareness of where the arrow should point.
```
I also did the following:
```
shareController.popoverPresentationController?.permittedArrowDirections = []
```
Because there is no context provided to this function to accurately represent where the arrow should point, I've removed the arrows.

## Related Issue
https://3sidedcube.atlassian.net/browse/SP-3010

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/925d01c3-d0c8-4f1c-abb9-9c19b66a0e63