### PR TITLE
Bugfix/SP-3008: Make sure "Finish" button shows on the quiz completion page

### DIFF
--- a/ThunderCloud/QuizCompletionViewController.swift
+++ b/ThunderCloud/QuizCompletionViewController.swift
@@ -112,12 +112,6 @@ open class QuizCompletionViewController: TableViewController {
     /// Defaults to a button to finish the quiz
     open var rightBarButtonItem: UIBarButtonItem? {
         get {
-            
-            // Don't show the right bar button on iPad unless we're being presented
-            if UIDevice.current.userInterfaceIdiom == .pad && self.presentingViewController == nil {
-                return nil
-            }
-            
             return UIBarButtonItem(
                 title: "Finish".localised(with: "_QUIZ_BUTTON_FINISH"),
                 style: .plain,


### PR DESCRIPTION
## Description
Remove the code blocking the "Finish" button being shown on the quiz completion page. I've raised this point on the ticket itself, it seems as though this was desired behaviour at one point.

## Related Issue
https://3sidedcube.atlassian.net/browse/SP-3008