### PR TITLE
Remove UIWebView support from OnePasswordExtension

### DIFF
--- a/ThunderCloud/OnePasswordExtension.h
+++ b/ThunderCloud/OnePasswordExtension.h
@@ -8,10 +8,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import <MobileCoreServices/MobileCoreServices.h>
-
-#ifdef __IPHONE_8_0
 #import <WebKit/WebKit.h>
-#endif
 
 #if __has_feature(nullability)
 NS_ASSUME_NONNULL_BEGIN
@@ -153,13 +150,13 @@ NS_CLASS_DEPRECATED_IOS(10_0, 13_0, "Deprecated for iOS 13 and above")
 
 /*!
  Called from your web view controller, this method will show all the saved logins for the active page in the provided web
- view, and automatically fill the HTML form fields. Supports both WKWebView and UIWebView.
+ view, and automatically fill the HTML form fields.
  
  @discussion 1Password will show all matching Login for the naked domain of the current website. For example if the user has an item in your 1Password vault with "subdomain1.domain.com” as the website and another one with "subdomain2.domain.com”, and the current website is "https://domain.com", 1Password will show both items.
  
  However, if no matching login is found for "https://domain.com", the 1Password Extension will display the "New Login" button so that the user can create a new Login for the current website.
  
- @param webView The web view which displays the form to be filled. The active UIWebView Or WKWebView. Must not be nil.
+ @param webView The web view which displays the form to be filled. Must be an active WKWebView. Must not be nil.
  
  @param viewController The view controller from which the 1Password Extension is invoked. Usually `self`
  
@@ -169,7 +166,7 @@ NS_CLASS_DEPRECATED_IOS(10_0, 13_0, "Deprecated for iOS 13 and above")
  
  @param completion Completion block called on completion with parameters success, and error. The success reply parameter that is YES if the 1Password Extension has been successfully completed or NO otherwise. The error reply parameter that is nil if the 1Password Extension has been successfully completed, or it contains error information about the completion failure.
  */
-- (void)fillItemIntoWebView:(nonnull id)webView forViewController:(nonnull UIViewController *)viewController sender:(nullable id)sender showOnlyLogins:(BOOL)yesOrNo completion:(nonnull OnePasswordSuccessCompletionBlock)completion;
+- (void)fillItemIntoWebView:(nonnull WKWebView *)webView forViewController:(nonnull UIViewController *)viewController sender:(nullable id)sender showOnlyLogins:(BOOL)yesOrNo completion:(nonnull OnePasswordSuccessCompletionBlock)completion;
 
 /*!
  Called in the UIActivityViewController completion block to find out whether or not the user selected the 1Password Extension activity.
@@ -183,27 +180,27 @@ NS_CLASS_DEPRECATED_IOS(10_0, 13_0, "Deprecated for iOS 13 and above")
 /*!
  The returned NSExtensionItem can be used to create your own UIActivityViewController. Use `isOnePasswordExtensionActivityType:` and `fillReturnedItems:intoWebView:completion:` in the activity view controller completion block to process the result. The completion block is guaranteed to be called on the main thread.
  
- @param webView The web view which displays the form to be filled. The active UIWebView Or WKWebView. Must not be nil.
+ @param webView The web view which displays the form to be filled. Must be an active WKWebView. Must not be nil.
  
  @param completion Completion block called on completion with extensionItem and error. The extensionItem reply parameter that is contains all the info required by the 1Password extension if has been successfully completed or nil otherwise. The error reply parameter that is nil if the 1Password extension item has been successfully created, or it contains error information about the completion failure.
  */
-- (void)createExtensionItemForWebView:(nonnull id)webView completion:(nonnull OnePasswordExtensionItemCompletionBlock)completion;
+- (void)createExtensionItemForWebView:(nonnull WKWebView *)webView completion:(nonnull OnePasswordExtensionItemCompletionBlock)completion;
 
 /*!
  Method used in the UIActivityViewController completion block to fill information into a web view.
  
  @param returnedItems Array which contains the selected activity in the share sheet. Empty array if the share sheet is cancelled by the user.
- @param webView The web view which displays the form to be filled. The active UIWebView Or WKWebView. Must not be nil.
+ @param webView The web view which displays the form to be filled. Must be an active WKWebView. Must not be nil.
  
  @param completion Completion block called on completion with parameters success, and error. The success reply parameter that is YES if the 1Password Extension has been successfully completed or NO otherwise. The error reply parameter that is nil if the 1Password Extension has been successfully completed, or it contains error information about the completion failure.
  */
-- (void)fillReturnedItems:(nullable NSArray *)returnedItems intoWebView:(nonnull id)webView completion:(nonnull OnePasswordSuccessCompletionBlock)completion;
+- (void)fillReturnedItems:(nullable NSArray *)returnedItems intoWebView:(nonnull WKWebView *)webView completion:(nonnull OnePasswordSuccessCompletionBlock)completion;
 
 /*!
  Deprecated in version 1.5
  @see Use fillItemIntoWebView:forViewController:sender:showOnlyLogins:completion: instead
  */
-- (void)fillLoginIntoWebView:(nonnull id)webView forViewController:(nonnull UIViewController *)viewController sender:(nullable id)sender completion:(nonnull OnePasswordSuccessCompletionBlock)completion __attribute__((deprecated("Use fillItemIntoWebView:forViewController:sender:showOnlyLogins:completion: instead. Deprecated in version 1.5")));
+- (void)fillLoginIntoWebView:(nonnull WKWebView *)webView forViewController:(nonnull UIViewController *)viewController sender:(nullable id)sender completion:(nonnull OnePasswordSuccessCompletionBlock)completion __attribute__((deprecated("Use fillItemIntoWebView:forViewController:sender:showOnlyLogins:completion: instead. Deprecated in version 1.5")));
 @end
 
 #if __has_feature(nullability)

--- a/ThunderCloud/OnePasswordExtension.m
+++ b/ThunderCloud/OnePasswordExtension.m
@@ -213,29 +213,15 @@ static os_log_t ui_log;
 
 #pragma mark - Web View filling Support
 
-- (void)fillItemIntoWebView:(nonnull id)webView forViewController:(nonnull UIViewController *)viewController sender:(nullable id)sender showOnlyLogins:(BOOL)yesOrNo completion:(nonnull OnePasswordSuccessCompletionBlock)completion {
-	NSAssert(webView != nil, @"webView must not be nil");
-	NSAssert(viewController != nil, @"viewController must not be nil");
-	NSAssert([webView isKindOfClass:[UIWebView class]] || [webView isKindOfClass:[WKWebView class]], @"webView must be an instance of WKWebView or UIWebView.");
+- (void)fillItemIntoWebView:(nonnull WKWebView *)webView forViewController:(nonnull UIViewController *)viewController sender:(nullable id)sender showOnlyLogins:(BOOL)yesOrNo completion:(nonnull OnePasswordSuccessCompletionBlock)completion {
+        NSAssert(webView != nil, @"webView must not be nil");
+        NSAssert(viewController != nil, @"viewController must not be nil");
 
-#ifdef __IPHONE_8_0
-	if ([webView isKindOfClass:[UIWebView class]]) {
-		[self fillItemIntoUIWebView:webView webViewController:viewController sender:(id)sender showOnlyLogins:yesOrNo completion:^(BOOL success, NSError *error) {
-			if (completion) {
-				completion(success, error);
-			}
-		}];
-	}
-	#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0 || ONE_PASSWORD_EXTENSION_ENABLE_WK_WEB_VIEW
-	else if ([webView isKindOfClass:[WKWebView class]]) {
-		[self fillItemIntoWKWebView:webView forViewController:viewController sender:(id)sender showOnlyLogins:yesOrNo completion:^(BOOL success, NSError *error) {
-			if (completion) {
-				completion(success, error);
-			}
-		}];
-	}
-	#endif
-#endif
+        [self fillItemIntoWKWebView:webView forViewController:viewController sender:(id)sender showOnlyLogins:yesOrNo completion:^(BOOL success, NSError *error) {
+                if (completion) {
+                        completion(success, error);
+                }
+        }];
 }
 
 #pragma mark - Support for custom UIActivityViewControllers
@@ -244,47 +230,33 @@ static os_log_t ui_log;
 	return [@"com.agilebits.onepassword-ios.extension" isEqualToString:activityType] || [@"com.agilebits.beta.onepassword-ios.extension" isEqualToString:activityType];
 }
 
-- (void)createExtensionItemForWebView:(nonnull id)webView completion:(nonnull OnePasswordExtensionItemCompletionBlock)completion {
-	NSAssert(webView != nil, @"webView must not be nil");
-	NSAssert([webView isKindOfClass:[UIWebView class]] || [webView isKindOfClass:[WKWebView class]], @"webView must be an instance of WKWebView or UIWebView.");
-	
-#ifdef __IPHONE_8_0
-	if ([webView isKindOfClass:[UIWebView class]]) {
-		UIWebView *uiWebView = (UIWebView *)webView;
-		NSString *collectedPageDetails = [uiWebView stringByEvaluatingJavaScriptFromString:OPWebViewCollectFieldsScript];
+- (void)createExtensionItemForWebView:(nonnull WKWebView *)webView completion:(nonnull OnePasswordExtensionItemCompletionBlock)completion {
+        NSAssert(webView != nil, @"webView must not be nil");
 
-		[self createExtensionItemForURLString:uiWebView.request.URL.absoluteString webPageDetails:collectedPageDetails completion:completion];
-	}
-	#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0 || ONE_PASSWORD_EXTENSION_ENABLE_WK_WEB_VIEW
-	else if ([webView isKindOfClass:[WKWebView class]]) {
-		WKWebView *wkWebView = (WKWebView *)webView;
-		[wkWebView evaluateJavaScript:OPWebViewCollectFieldsScript completionHandler:^(NSString *result, NSError *evaluateError) {
-			if (result == nil) {
-				os_log_debug(ui_log, "1Password Extension failed to collect web page fields: %@", evaluateError);
-				NSError *failedToCollectFieldsError = [OnePasswordExtension failedToCollectFieldsErrorWithUnderlyingError:evaluateError];
-				if (completion) {
-					if ([NSThread isMainThread]) {
-						completion(nil, failedToCollectFieldsError);
-					}
-					else {
-						dispatch_async(dispatch_get_main_queue(), ^{
-							completion(nil, failedToCollectFieldsError);
-						});
-					}
-				}
+        [webView evaluateJavaScript:OPWebViewCollectFieldsScript completionHandler:^(NSString *result, NSError *evaluateError) {
+                if (result == nil) {
+                        os_log_debug(ui_log, "1Password Extension failed to collect web page fields: %@", evaluateError);
+                        NSError *failedToCollectFieldsError = [OnePasswordExtension failedToCollectFieldsErrorWithUnderlyingError:evaluateError];
+                        if (completion) {
+                                if ([NSThread isMainThread]) {
+                                        completion(nil, failedToCollectFieldsError);
+                                }
+                                else {
+                                        dispatch_async(dispatch_get_main_queue(), ^{
+                                                completion(nil, failedToCollectFieldsError);
+                                        });
+                                }
+                        }
 
-				return;
-			}
+                        return;
+                }
 
-			[self createExtensionItemForURLString:wkWebView.URL.absoluteString webPageDetails:result completion:completion];
-		}];
-	}
-	#endif
-#endif
+                [self createExtensionItemForURLString:webView.URL.absoluteString webPageDetails:result completion:completion];
+        }];
 }
 
-- (void)fillReturnedItems:(nullable NSArray *)returnedItems intoWebView:(nonnull id)webView completion:(nonnull OnePasswordSuccessCompletionBlock)completion {
-	NSAssert(webView != nil, @"webView must not be nil");
+- (void)fillReturnedItems:(nullable NSArray *)returnedItems intoWebView:(nonnull WKWebView *)webView completion:(nonnull OnePasswordSuccessCompletionBlock)completion {
+        NSAssert(webView != nil, @"webView must not be nil");
 
 	if (returnedItems.count == 0) {
 		NSError *error = [OnePasswordExtension extensionCancelledByUserError];
@@ -323,7 +295,7 @@ static os_log_t ui_log;
 #endif
 }
 
-- (void)findLoginIn1PasswordWithURLString:(nonnull NSString *)URLString collectedPageDetails:(nullable NSString *)collectedPageDetails forWebViewController:(nonnull UIViewController *)forViewController sender:(nullable id)sender withWebView:(nonnull id)webView showOnlyLogins:(BOOL)yesOrNo completion:(nonnull OnePasswordSuccessCompletionBlock)completion {
+- (void)findLoginIn1PasswordWithURLString:(nonnull NSString *)URLString collectedPageDetails:(nullable NSString *)collectedPageDetails forWebViewController:(nonnull UIViewController *)forViewController sender:(nullable id)sender withWebView:(nonnull WKWebView *)webView showOnlyLogins:(BOOL)yesOrNo completion:(nonnull OnePasswordSuccessCompletionBlock)completion {
 	if ([URLString length] == 0) {
 		NSError *URLStringError = [OnePasswordExtension failedToObtainURLStringFromWebViewError];
 		os_log_error(ui_log, "Failed to findLoginIn1PasswordWithURLString: %@", URLStringError);
@@ -388,37 +360,26 @@ static os_log_t ui_log;
 	[forViewController presentViewController:activityViewController animated:YES completion:nil];
 }
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0 || ONE_PASSWORD_EXTENSION_ENABLE_WK_WEB_VIEW
 - (void)fillItemIntoWKWebView:(nonnull WKWebView *)webView forViewController:(nonnull UIViewController *)viewController sender:(nullable id)sender showOnlyLogins:(BOOL)yesOrNo completion:(nonnull OnePasswordSuccessCompletionBlock)completion {
-	[webView evaluateJavaScript:OPWebViewCollectFieldsScript completionHandler:^(NSString *result, NSError *error) {
-		if (result == nil) {
-			os_log_error(ui_log, "1Password Extension failed to collect web page fields: %@", error);
-			if (completion) {
-				completion(NO,[OnePasswordExtension failedToCollectFieldsErrorWithUnderlyingError:error]);
-			}
+        [webView evaluateJavaScript:OPWebViewCollectFieldsScript completionHandler:^(NSString *result, NSError *error) {
+                if (result == nil) {
+                        os_log_error(ui_log, "1Password Extension failed to collect web page fields: %@", error);
+                        if (completion) {
+                                completion(NO,[OnePasswordExtension failedToCollectFieldsErrorWithUnderlyingError:error]);
+                        }
 
-			return;
-		}
+                        return;
+                }
 
-		[self findLoginIn1PasswordWithURLString:webView.URL.absoluteString collectedPageDetails:result forWebViewController:viewController sender:sender withWebView:webView showOnlyLogins:yesOrNo completion:^(BOOL success, NSError *findLoginError) {
-			if (completion) {
-				completion(success, findLoginError);
-			}
-		}];
-	}];
-}
-#endif
-
-- (void)fillItemIntoUIWebView:(nonnull UIWebView *)webView webViewController:(nonnull UIViewController *)viewController sender:(nullable id)sender showOnlyLogins:(BOOL)yesOrNo completion:(nonnull OnePasswordSuccessCompletionBlock)completion {
-	NSString *collectedPageDetails = [webView stringByEvaluatingJavaScriptFromString:OPWebViewCollectFieldsScript];
-	[self findLoginIn1PasswordWithURLString:webView.request.URL.absoluteString collectedPageDetails:collectedPageDetails forWebViewController:viewController sender:sender withWebView:webView showOnlyLogins:yesOrNo completion:^(BOOL success, NSError *error) {
-		if (completion) {
-			completion(success, error);
-		}
-	}];
+                [self findLoginIn1PasswordWithURLString:webView.URL.absoluteString collectedPageDetails:result forWebViewController:viewController sender:sender withWebView:webView showOnlyLogins:yesOrNo completion:^(BOOL success, NSError *findLoginError) {
+                        if (completion) {
+                                completion(success, findLoginError);
+                        }
+                }];
+        }];
 }
 
-- (void)executeFillScript:(NSString * __nullable)fillScript inWebView:(nonnull id)webView completion:(nonnull OnePasswordSuccessCompletionBlock)completion {
+- (void)executeFillScript:(NSString * __nullable)fillScript inWebView:(nonnull WKWebView *)webView completion:(nonnull OnePasswordSuccessCompletionBlock)completion {
 
 	if (fillScript == nil) {
 		os_log_debug(ui_log, "Failed to executeFillScript, fillScript is missing");
@@ -429,43 +390,22 @@ static os_log_t ui_log;
 		return;
 	}
 
-	NSMutableString *scriptSource = [OPWebViewFillScript mutableCopy];
-	[scriptSource appendFormat:@"(document, %@, undefined);", fillScript];
+        NSMutableString *scriptSource = [OPWebViewFillScript mutableCopy];
+        [scriptSource appendFormat:@"(document, %@, undefined);", fillScript];
 
-#ifdef __IPHONE_8_0
-	if ([webView isKindOfClass:[UIWebView class]]) {
-		NSString *result = [((UIWebView *)webView) stringByEvaluatingJavaScriptFromString:scriptSource];
-		BOOL success = (result != nil);
-		NSError *error = nil;
+        [webView evaluateJavaScript:scriptSource completionHandler:^(NSString *result, NSError *evaluationError) {
+                BOOL success = (result != nil);
+                NSError *error = nil;
 
-		if (!success) {
-			os_log_debug(ui_log, "Cannot executeFillScript, stringByEvaluatingJavaScriptFromString failed");
-			error = [OnePasswordExtension failedToFillFieldsErrorWithLocalizedErrorMessage:NSLocalizedStringFromTable(@"Failed to fill web page because script could not be evaluated", @"OnePasswordExtension", @"1Password Extension Error Message") underlyingError:nil];
-		}
+                if (!success) {
+                        os_log_error(ui_log, "Cannot executeFillScript, evaluateJavaScript failed: %@", evaluationError);
+                        error = [OnePasswordExtension failedToFillFieldsErrorWithLocalizedErrorMessage:NSLocalizedStringFromTable(@"Failed to fill web page because script could not be evaluated", @"OnePasswordExtension", @"1Password Extension Error Message") underlyingError:evaluationError];
+                }
 
-		if (completion) {
-			completion(success, error);
-		}
-	}
-	
-	#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0 || ONE_PASSWORD_EXTENSION_ENABLE_WK_WEB_VIEW
-	else if ([webView isKindOfClass:[WKWebView class]]) {
-		[((WKWebView *)webView) evaluateJavaScript:scriptSource completionHandler:^(NSString *result, NSError *evaluationError) {
-			BOOL success = (result != nil);
-			NSError *error = nil;
-
-			if (!success) {
-				os_log_error(ui_log, "Cannot executeFillScript, evaluateJavaScript failed: %@", evaluationError);
-				error = [OnePasswordExtension failedToFillFieldsErrorWithLocalizedErrorMessage:NSLocalizedStringFromTable(@"Failed to fill web page because script could not be evaluated", @"OnePasswordExtension", @"1Password Extension Error Message") underlyingError:error];
-			}
-
-			if (completion) {
-				completion(success, error);
-			}
-		}];
-	}
-	#endif
-#endif
+                if (completion) {
+                        completion(success, error);
+                }
+        }];
 }
 
 #ifdef __IPHONE_8_0
@@ -696,8 +636,8 @@ function y(a){var b;if(void 0===a||null===a)return null;try{var c=Array.prototyp
  Deprecated in version 1.5
  Use fillItemIntoWebView:forViewController:sender:showOnlyLogins:completion: instead
  */
-- (void)fillLoginIntoWebView:(nonnull id)webView forViewController:(nonnull UIViewController *)viewController sender:(nullable id)sender completion:(nonnull OnePasswordSuccessCompletionBlock)completion {
-	[self fillItemIntoWebView:webView forViewController:viewController sender:sender showOnlyLogins:YES completion:completion];
+- (void)fillLoginIntoWebView:(nonnull WKWebView *)webView forViewController:(nonnull UIViewController *)viewController sender:(nullable id)sender completion:(nonnull OnePasswordSuccessCompletionBlock)completion {
+        [self fillItemIntoWebView:webView forViewController:viewController sender:sender showOnlyLogins:YES completion:completion];
 }
 
 @end


### PR DESCRIPTION
## Summary
- Require `WKWebView` in OnePasswordExtension's public API
- Drop legacy `UIWebView` code paths and always use `evaluateJavaScript`

## Testing
- `xcodebuild -list` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories)*

------
https://chatgpt.com/codex/tasks/task_b_6894a8e84058832f838abf85768be97a