### PR TITLE
Allow overriding of external browser web link handling

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "3sidedcube/Baymax" "2d743f903e30141df58b954cc8b4e235ccab862a"
 github "3sidedcube/ThunderBasics" "0a5f9a9222ce4d4d2d5e4b635d0f14c70a449653"
 github "3sidedcube/ThunderCollection" "47af6b0d0b5c63116e11eca4984a869407ae294b"
-github "3sidedcube/ThunderRequest" "fe6ea6e94929052a5461c37bea84877bc1995a04"
-github "3sidedcube/ThunderTable" "6ecb8328b5071fec05fa1f4142f3f13f0d0a0387"
+github "3sidedcube/ThunderRequest" "c07e965cd60ffa3a4b14ce405d007314320a34d9"
+github "3sidedcube/ThunderTable" "5ca85807366776ccedb523421dfa3ea1eec4bfb6"

--- a/ThunderCloud/NavigationController.swift
+++ b/ThunderCloud/NavigationController.swift
@@ -132,8 +132,8 @@ public extension UINavigationController {
         
         if scheme == "mailto", let url = link.url, UIApplication.shared.canOpenURL(url) {
             
-            UIApplication.shared.open(url, options: [:], completionHandler: nil)
-            
+            handleMail(url: url)
+
         } else if scheme == "itunes", let url = link.url {
             
             handleITunes(url: url)
@@ -155,42 +155,13 @@ public extension UINavigationController {
             handleSMS(link: link)
             
         } else if link.linkClass == .native, let destination = link.destination {
-            
-            if let handler = StormGenerator.shared.nativeLinkHandler, handler(destination, self) {
-                return
-            }
-            
-            guard let viewController = StormGenerator.viewController(nativePageName: destination) else {
-                return
-            }
-            
-            let keyWindow = UIApplication.shared.appKeyWindow
-            let isIPad = UIDevice.current.userInterfaceIdiom == .pad
-            if let splitViewController = keyWindow?.rootViewController as? SplitViewController, isIPad {
-                
-                splitViewController.setRightViewController(viewController, from: self)
-                //                splitViewController.show(viewController, sender: self)
-                
-            } else if viewController is UINavigationController {
-                
-                present(viewController, animated: true, completion: nil)
-                
-            } else {
-                
-                show(viewController: viewController, animated: true)
-            }
-            
+
+            handleNative(destination: destination)
+
         } else if scheme == "tel", let url = link.url {
             
-            let urlString = url.absoluteString.replacingOccurrences(of: "tel", with: "telprompt")
-            guard let telephoneUrl = URL(string: urlString) else { return }
-            
-            if UIApplication.shared.canOpenURL(telephoneUrl) {
-                UIApplication.shared.open(telephoneUrl, options: [:], completionHandler: nil)
-            }
-            
-            NotificationCenter.default.sendAnalyticsHook(.call(url))
-            
+            handlePhone(url: url)
+
         } else if link.linkClass == .share {
             
             handleShare(link: link)
@@ -212,7 +183,11 @@ public extension UINavigationController {
     
     //MARK: -
     //MARK: Link handlers!
-    
+
+    private func handleMail(url: URL) {
+        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+    }
+
     private func handleITunes(url: URL) {
         
         guard let host = url.host, let iTunesIdentifier = Int(host) else { return }
@@ -402,7 +377,44 @@ public extension UINavigationController {
             NotificationCenter.default.sendAnalyticsHook(.sms(link.recipients ?? [], link.body))
         }
     }
-    
+
+    private func handleNative(destination: String) {
+        if let handler = StormGenerator.shared.nativeLinkHandler, handler(destination, self) {
+            return
+        }
+
+        guard let viewController = StormGenerator.viewController(nativePageName: destination) else {
+            return
+        }
+
+        let keyWindow = UIApplication.shared.appKeyWindow
+        let isIPad = UIDevice.current.userInterfaceIdiom == .pad
+        if let splitViewController = keyWindow?.rootViewController as? SplitViewController, isIPad {
+
+            splitViewController.setRightViewController(viewController, from: self)
+            //                splitViewController.show(viewController, sender: self)
+
+        } else if viewController is UINavigationController {
+
+            present(viewController, animated: true, completion: nil)
+
+        } else {
+
+            show(viewController: viewController, animated: true)
+        }
+    }
+
+    private func handlePhone(url: URL) {
+        let urlString = url.absoluteString.replacingOccurrences(of: "tel", with: "telprompt")
+        guard let telephoneUrl = URL(string: urlString) else { return }
+
+        if UIApplication.shared.canOpenURL(telephoneUrl) {
+            UIApplication.shared.open(telephoneUrl, options: [:], completionHandler: nil)
+        }
+
+        NotificationCenter.default.sendAnalyticsHook(.call(url))
+    }
+
     private func handleShare(link: StormLink) {
         guard let body = link.body else { return }
 

--- a/ThunderCloud/NavigationController.swift
+++ b/ThunderCloud/NavigationController.swift
@@ -120,7 +120,7 @@ public extension UINavigationController {
     ///
     /// - Parameter link: A `StormLink` to decide which action to perform
     func push(link: StormLink) {
-        
+
         if let appDelegate = UIApplication.shared.delegate as? TSCAppDelegate, !appDelegate.linkIsSafelisted(link) {
             print("[Storm] Tried to push \(link.url?.absoluteString ?? "??") which is not a safelisted link")
             return
@@ -208,10 +208,9 @@ public extension UINavigationController {
     private func handleWeb(link: StormLink) {
         
         if link.linkClass == .uri {
-            
             guard let url = link.url else { return }
+            guard let handler = StormGenerator.shared.webLinkHandler, handler(url) else { return }
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
-            
         } else {
             var navigationController = self
 

--- a/ThunderCloud/StormGenerator.swift
+++ b/ThunderCloud/StormGenerator.swift
@@ -16,6 +16,16 @@ import ThunderBasics
 /// - Returns: A boolean as to whether the link was handled or not
 public typealias NativeLinkHandler = (_ name: String, _ navigationController: UINavigationController) -> Bool
 
+/// A block which is called to handle external web links before ThunderCloud presents them itself.
+///
+/// This closure lets your app intercept links that are classified as web/URI (e.g. scheme == "http", "https", or custom
+/// URIs when `StormLink.linkClass == .uri`) and decide how to handle them. If you return `true`, ThunderCloud assumes
+/// you've handled the link. If you return `false`, ThunderCloud will fall back to its default behaviour.
+///
+/// - Parameter url: The URL to be handled.
+/// - Returns: `true` if your app handled the URL and no further action should be taken; `false` to allow the default handling.
+public typealias WebLinkHandler = (_ url: URL) -> Bool
+
 /// Generates view controllers from URL's, page ID's and names and returns an optional `UIViewController` so that it can be type checked against custom types.
 ///
 /// Also generates images from their storm object representations
@@ -29,7 +39,27 @@ public class StormGenerator: NSObject {
     ///
     /// This can be used for example to catch links with specific names and show custom UI or perform custom actions
     public var nativeLinkHandler: NativeLinkHandler?
-    
+
+    /// An optional handler for web/URI links.
+    ///
+    /// If set, this handler is called when a link is considered a web/URI link.
+    /// Returning `true` indicates you have handled the URL; returning `false` lets ThunderCloud present the URL.
+    /// If `nil`, ThunderCloud will always use its default handling.
+    ///
+    /// Usage example:
+    /// ```swift
+    /// StormGenerator.shared.webLinkHandler = { url in
+    ///     // Intercept certain hosts and open them in-app
+    ///     if url.host == "example.com" {
+    ///         // e.g. route to a custom screen or use a first-party web view
+    ///         UIApplication.shared.open(url)
+    ///         return true
+    ///     }
+    ///     return false // use ThunderCloud default
+    /// }
+    /// ```
+    public var webLinkHandler: WebLinkHandler?
+
     /// A dictionary of maps between native page names and either a UIViewController class or a dictionary representing where in a storyboard to instantiate it from
     public var nativePageLookupDictionary: [AnyHashable : Any] = [:]
     


### PR DESCRIPTION
## What?

- Moved all of the link handlers into their own functions so that the logic is a bit easier to read and understand.
- Added a new `webLinkHandler` to `StormGenerator` which allows the app using ThunderCloud to override the handling of links that should open in an external browser.

## Why?

In the Blood app, the user can set an in-app preference for their external browser. Links in Storm pages should also respect this preference, so allowing this override enables this.