### PR TITLE
fix(security): SEC-619 raise minimum deployment target to iOS 17

### DIFF
--- a/ThunderCloud.xcodeproj/project.pbxproj
+++ b/ThunderCloud.xcodeproj/project.pbxproj
@@ -1807,7 +1807,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -1862,7 +1862,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -1894,14 +1894,14 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = ThunderCloud/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 4.3.0;
+				MARKETING_VERSION = 4.3.3;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu99 gnu++11";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.threesidedcube.$(PRODUCT_NAME:rfc1034identifier)";
@@ -1934,14 +1934,14 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = ThunderCloud/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 4.3.0;
+				MARKETING_VERSION = 4.3.3;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu99 gnu++11";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.threesidedcube.$(PRODUCT_NAME:rfc1034identifier)";
@@ -1966,7 +1966,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = ThunderCloudTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1993,7 +1993,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = ThunderCloudTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
## Why

Pen test finding (SEC-619): embedded frameworks of the Blood iOS app declare EOL minimum OS versions. ThunderCloud declared iOS 15.0 (project-level) / 16.0 (framework target), both end-of-life. This raises the minimum deployment target to iOS 17.0.

## What changed

- `IPHONEOS_DEPLOYMENT_TARGET` raised to **17.0** in all 6 build configurations in `project.pbxproj` (was 15.0 at project level and tests target, 16.0 on the framework target). No xcconfig, Package.swift, or podspec exists in this repo.
- `MARKETING_VERSION` bumped **4.3.0 → 4.3.3** to match the release branch.
- Cartfile pins to other Thunder frameworks left unchanged — version bumps coordinated separately.

## Build & test results

- `xcodebuild build` (ThunderCloud scheme, generic/platform=iOS, Release): **BUILD SUCCEEDED**
- `xcodebuild test` (iPhone 16 simulator): **TEST SUCCEEDED** — 60 tests, 0 failures

## New deprecation warnings

**None introduced by this bump** — zero "deprecated in iOS 17" warnings. Pre-existing warnings (1× iOS 15, 14× iOS 16 deprecations, e.g. `Locale.languageCode`/`regionCode`/`characterDirection(forLanguage:)` in `StormLanguageController`, `StormLink+Localised`, `EditLocalisationRow`) were already present at the previous 16.0 target and are unchanged.

## Note for consumers

Consumer apps must target **iOS >= 17.0** to adopt this version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)